### PR TITLE
Make imports in api.py relative

### DIFF
--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -5,8 +5,8 @@ from bravado.client import SwaggerClient
 from bravado.swagger_model import load_file
 from simplejson import JSONDecodeError
 
-from models import Project, MapToken
-from exceptions import RefreshTokenException
+from .models import Project, MapToken
+from .exceptions import RefreshTokenException
 
 
 SPEC_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
Overview
------

Without relative imports, the installed package was looking for a globally available module called `models` to import, which it couldn't find. Relative import lets it know to use the `models` module in itself.

Testing
------

- create a python 3 virtualenv: `python3 -m venv venv`
- activate it
- `pip install -e .`
- open a python3 shell
- try to import the API:
```python
from rasterfoundry.api import API
```
- if that doesn't fail, you win
- do the same for python 2, starting with `virtualenv venv` instead of `python3 -m venv venv`