### PR TITLE
Bump cryptography version to 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['tests']),
     package_data={'': ['*.yml']},
     install_requires=[
-        'cryptography == 1.8.1',
+        'cryptography >= 2.0.0',
         'pyasn1 >= 0.2.3',
         'requests >= 2.9.1',
         'bravado >= 8.4.0',


### PR DESCRIPTION
# Overview

Bump `cryptography` version to `2.x` to take advantage of the new `manylinux1 wheel` [installation method](https://cryptography.io/en/latest/installation/#building-cryptography-on-linux). This will enable us to install the module without installing any additional development packages.

# Notes

Although tests were passing in CI, Travis CI build machines include `python-dev` so my changes weren't actually being tested.  As a workaround, I included a `Dockerfile` based off of Ubuntu Trusty so that I could test installation on a clean Ubuntu setup. It will be removed before this PR is merged.

# Testing
- Build the Docker container, make sure that the `pip`  installation completes successfully. Then, attempt to use the API.

```bash
$ docker build -t rf-python .
$ docker run -it rf-python python 
Python 2.7.6 (default, Oct 26 2016, 20:30:19) 
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from rasterfoundry.API import API
>>> rf = API(refresh_token="<>")
>>> rf.projects
[<Project - test>]
```
Fixes #19 