### PR TITLE
Add *args and **kwargs to no_op function in notebook support check

### DIFF
--- a/rasterfoundry/decorators.py
+++ b/rasterfoundry/decorators.py
@@ -4,7 +4,7 @@ from . import NOTEBOOK_SUPPORT
 
 
 def check_notebook(f):
-    def no_op():
+    def no_op(*args, **kwargs):
         logging.warn('This function requires jupyter notebook and ipyleaflet')
         return
 

--- a/tests/test_notebook_check.py
+++ b/tests/test_notebook_check.py
@@ -9,6 +9,17 @@ def test_warn_without_notebook_support():
     assert f() is None
 
 
+def test_warn_without_notebook_support_with_args():
+    import rasterfoundry.decorators
+    rasterfoundry.decorators.NOTEBOOK_SUPPORT = False
+    from rasterfoundry.decorators import check_notebook
+
+    @check_notebook
+    def f(*args, **kwargs):
+        return 'foo'
+    assert f(1, 2, 3, foo='bar') is None
+
+
 def test_no_warn_with_notebook_support():
     import rasterfoundry.decorators
     rasterfoundry.decorators.NOTEBOOK_SUPPORT = True


### PR DESCRIPTION
Overview
------

When the function that fails the notebook check takes arguments, those arguments get passed to whatever the `@check_notebook` decorator returns. Since `no_op` takes no arguments, this causes a `TypeError` in real life that wasn't exercised by the test. This PR fixes the `no_op` function the decorator returns and adds a test that exercises this case.

Testing
------

- verify that the [new test](https://github.com/raster-foundry/raster-foundry-python-client/blob/a7d63b1d686aa72cb263649981ef4a5a012854d3/tests/test_notebook_check.py#L12-L20) exercises this problem

Closes nothing