### PR TITLE
Minor usability fixes

### DIFF
--- a/rasterfoundry/exceptions.py
+++ b/rasterfoundry/exceptions.py
@@ -3,3 +3,7 @@
 
 class RefreshTokenException(Exception):
     pass
+
+
+class GatewayTimeoutException(Exception):
+    pass

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -89,7 +89,7 @@ class Project(object):
         PNGs will be returned if the export_format is anything other than tiff
 
         Args:
-            bbox (str): GeoJSON format bounding box for the download
+            bbox (str): Bounding box (formatted as 'x1,y1,x2,y2') for the download
             export_format (str): Requested download format
 
         Returns:
@@ -120,7 +120,7 @@ class Project(object):
         The returned string is the raw bytes of the associated geotiff.
 
         Args:
-            bbox (str): GeoJSON format bounding box for the download
+            bbox (str): Bounding box (formatted as 'x1,y1,x2,y2') for the download
             zoom (int): zoom level for the export
 
         Returns:
@@ -135,7 +135,7 @@ class Project(object):
         The returned string is the raw bytes of the associated png.
 
         Args:
-            bbox (str): GeoJSON format bounding box for the download
+            bbox (str): Bounding box (formatted as 'x1,y1,x2,y2') for the download
             zoom (int): zoom level for the export
 
         Returns

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     readme_renderer
     pytest-runner
     pytest
-    
+
 commands =
     check-manifest --ignore tox.ini,tests*
     {envpython} setup.py check -m -r -s
@@ -24,3 +24,4 @@ commands =
 [flake8]
 exclude = .tox,*.egg,build,data
 select = E,W,F
+max-line-length = 100


### PR DESCRIPTION
# Overview
A few tweaks to make the client more ergonomic:
- Clarifies the bounding box format which is required.
- Raises exceptions with a helpful suggestion when export requests time out, and raises an exception when they error otherwise.

# Testing instructions
- `source venv/bin/activate`
- `jupyter notebook`
- Use the `Projects.ipynb` example or your own to get to the point where you have a `Project` object that you can call `geotiff()` on.
- Confirm that calling `.geotiff()` and `.png()` on the project object works generally.
- Confirm that setting the `zoom` parameter really high when calling the previous two functions results in a `GatewayTimeoutException` with a helpful message being raised.
- Confirm that passing in garbage for the `bbox` parameter causes an exception to be raised.