### PR TITLE
Start raster-vision predict job

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Usage
 
 .. code-block:: python
 
-   from rf.api import API
+   from rasterfoundry.api import API
    refresh_token = '<>'
 
    api = API(refresh_token=refresh_token)


### PR DESCRIPTION
This PR adds a method to the `Project` class that starts a raster-vision predict job on AWS Batch.  This job will download the image files associated with the project, and then run object detection on them. To test this PR, you can run the following snippet which will start a job in the R&D account, and will place the predictions for the Oakland project in `s3://raster-vision/results/detection/predict/lhf_test/predictions.json`. You can then view the output along with the original TIFF file in QGIS. To get the URI for the TIFF file, you can run `proj.get_image_source_uris()`.

```
from rasterfoundry.api import API
token = ''
api = API(refresh_token=token)
proj = api.projects[0]

proj.start_predict_job(
    's3://raster-vision/results/detection/train/lhf_ships_neg0/train/inference_graph.pb',
    's3://raster-vision/datasets/detection/ships_label_map.pbtxt',
    's3://raster-vision/results/detection/predict/lhf_test/predictions.json')
```