### PR TITLE
Add method to start prep_train_data job

### DIFF
--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -2,12 +2,13 @@
 import requests
 import uuid
 
-import boto3
-
 from .. import NOTEBOOK_SUPPORT
 from ..decorators import check_notebook
 from ..exceptions import GatewayTimeoutException
+from ..utils import start_raster_vision_job
+from ..settings import RV_CPU_JOB_DEF, RV_CPU_QUEUE, DEVELOP_BRANCH
 from .map_token import MapToken
+
 
 if NOTEBOOK_SUPPORT:
     from ipyleaflet import (
@@ -15,42 +16,6 @@ if NOTEBOOK_SUPPORT:
         SideBySideControl,
         TileLayer,
     )
-
-RV_CPU_QUEUE = 'raster-vision-cpu'
-RV_CPU_JOB_DEF = 'raster-vision-cpu'
-DEVELOP_BRANCH = 'develop'
-
-
-def start_raster_vision_job(job_name, command, job_queue=RV_CPU_QUEUE,
-                            job_definition=RV_CPU_JOB_DEF,
-                            branch_name=DEVELOP_BRANCH, attempts=1):
-    """Start a raster-vision Batch job.
-
-    Args:
-        job_name (str): name of the Batch job
-        command (str): command to run inside the Docker container
-        job_queue (str): name of the Batch job queue to run the job in
-        job_definition (str): name of the Batch job definition
-        branch_name (str): branch of the raster-vision repo to use
-        attempts (int): number of attempts for the Batch job
-
-    Returns:
-        job_id (str): job_id of job started on Batch
-    """
-    batch_client = boto3.client('batch')
-    # `run_script.sh $branch_name $command` downloads a branch of the
-    # raster-vision repo and then runs the command.
-    job_command = ['run_script.sh', branch_name, command]
-    job_id = batch_client.submit_job(
-        jobName=job_name, jobQueue=job_queue, jobDefinition=job_definition,
-        containerOverrides={
-            'command': job_command
-        },
-        retryStrategy={
-            'attempts': attempts
-        })['jobId']
-
-    return job_id
 
 
 class Project(object):

--- a/rasterfoundry/settings.py
+++ b/rasterfoundry/settings.py
@@ -1,0 +1,4 @@
+RV_CPU_QUEUE = 'raster-vision-cpu'
+RV_CPU_JOB_DEF = 'raster-vision-cpu'
+RV_CONFIG_URI_ROOT = 's3://raster-vision/datasets/detection/configs'
+DEVELOP_BRANCH = 'develop'

--- a/rasterfoundry/utils.py
+++ b/rasterfoundry/utils.py
@@ -1,0 +1,65 @@
+from future.standard_library import install_aliases  # noqa
+install_aliases()  # noqa
+from urllib.parse import urlparse
+from os.path import join
+import tempfile
+import uuid
+import json
+
+import boto3
+
+
+def start_raster_vision_job(job_name, command, job_queue, job_definition,
+                            branch_name, attempts=1):
+    """Start a raster-vision Batch job.
+
+    Args:
+        job_name (str): name of the Batch job
+        command (str): command to run inside the Docker container
+        job_queue (str): name of the Batch job queue to run the job in
+        job_definition (str): name of the Batch job definition
+        branch_name (str): branch of the raster-vision repo to use
+        attempts (int): number of attempts for the Batch job
+
+    Returns:
+        job_id (str): job_id of job started on Batch
+    """
+    batch_client = boto3.client('batch')
+    # `run_script.sh $branch_name $command` downloads a branch of the
+    # raster-vision repo and then runs the command.
+    job_command = ['run_script.sh', branch_name, command]
+    job_id = batch_client.submit_job(
+        jobName=job_name, jobQueue=job_queue, jobDefinition=job_definition,
+        containerOverrides={
+            'command': job_command
+        },
+        retryStrategy={
+            'attempts': attempts
+        })['jobId']
+
+    return job_id
+
+
+def upload_raster_vision_config(config_dict, config_uri_root):
+    """Upload a config file to S3
+
+    Args:
+        config_dict: a dictionary to turn into a JSON file to upload
+        config_uri_root: the root of the URI to upload the config to
+
+    Returns:
+        remote URI of the config file generate using a UUID
+    """
+    with tempfile.NamedTemporaryFile('w') as config_file:
+        json.dump(config_dict, config_file)
+        config_uri = join(
+            config_uri_root, '{}.json'.format(uuid.uuid1()))
+        s3 = boto3.resource('s3')
+        parsed_uri = urlparse(config_uri)
+        # Rewind file to beginning so that full content will be loaded.
+        # Without this line 0 bytes are uploaded.
+        config_file.seek(0)
+        s3.meta.client.upload_file(
+            config_file.name, parsed_uri.netloc, parsed_uri.path[1:])
+
+        return config_uri

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setuptools.setup(
         'pyasn1 >= 0.2.3',
         'requests >= 2.9.1',
         'bravado >= 8.4.0',
-        'boto3 >= 1.4.4'
+        'boto3 >= 1.4.4',
+        'future >= 0.16.0'
     ],
     extras_require={
         'notebook': [


### PR DESCRIPTION
### Overview
This PR adds a method to start raster-vision jobs that run the `prep_train_data` script. This allows one to easily generate training data zip files given projects ids and annotation URIs. This is related to https://github.com/azavea/raster-vision/pull/142. 

### Testing
```
from rasterfoundry.api import API
token = ...
api = API(refresh_token=token)

project_ids = [
    '357ddf1f-2e5e-4420-8e75-0eed12d2d20f',
    '4f073c7e-978e-483e-9848-17010cbad468',
    '72d1eadb-2e4b-4e07-81d6-cc78a1ff29a1',
    '7030c078-cf3e-403f-934a-cef039e56b2d',
    'f38d0ea0-1b11-4256-9ca6-5464ca30bbaf'
]

annotation_uris = [
    's3://raster-vision/datasets/detection/jm_ships/2017-09-18-singapore-final.geojson',
    's3://raster-vision/datasets/detection/jm_ships/2017-08-20-hong-kong-final.geojson',
    's3://raster-vision/datasets/detection/jm_ships/2017-08-27-richmond-final.geojson',
    's3://raster-vision/datasets/detection/jm_ships/2017-08-01-singapore-final.geojson',
    's3://raster-vision/datasets/detection/jm_ships/2017-08-08-long-beach-final.geojson'
]

output_zip_uri = 's3://raster-vision/datasets/detection/jm_ships_test.zip'

api.start_prep_train_data_job(project_ids, annotation_uris, output_zip_uri)
```

Closes #31 