### PR TITLE
Add Planet Upload Support

### DIFF
--- a/rasterfoundry/models/__init__.py
+++ b/rasterfoundry/models/__init__.py
@@ -1,2 +1,3 @@
-from .project import Project  # NOQA
+from .project import Project # NOQA
 from .map_token import MapToken # NOQA
+from .upload import Upload # NOQA

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -88,7 +88,7 @@ class Project(object):
         Returns:
             Project: created object in Raster Foundry
         """
-        return api.client.Imagery.post_projects(project_create)
+        return api.client.Imagery.post_projects(project=project_create)
 
     def get_center(self):
         """Get the center of this project's extent"""

--- a/rasterfoundry/models/upload.py
+++ b/rasterfoundry/models/upload.py
@@ -30,6 +30,42 @@ class Upload(object):
         self.files = upload.files
 
     @classmethod
+    def upload_create_from_planet(
+            cls, datasource, organization, planet_ids,
+            metadata={}, visibility='PRIVATE', project_id=None
+    ):
+        """
+        Args:
+            datasource (str): UUID of the datasource this upload belongs to
+            organization (str): UUID of the organization this upload belongs to
+            planet_ids (list[str]): list of IDs from Planet to import
+            metadata (dict): Additional information to store with this upload.
+                acquisitionDate and cloudCover will be parsed into any created
+                scenes.
+            visibility (str): PUBLIC, PRIVATE, or ORGANIZATION visibility level
+                for the created scenes
+            project_id (str): UUID of the project scenes from this upload
+                should be added to
+
+        Returns:
+            dict: splattable object to post to /uploads/
+        """
+        upload_status = 'UPLOADED'
+        file_type = 'GEOTIFF'
+
+        return dict(
+            uploadStatus=upload_status,
+            files=planet_ids,
+            uploadType='PLANET',
+            fileType=file_type,
+            datasource=datasource,
+            organizationId=organization,
+            metadata=metadata,
+            visibility=visibility,
+            projectId=project_id
+        )
+
+    @classmethod
     def upload_create_from_files(
             cls, datasource, organization, paths_to_tifs,
             dest_bucket, dest_prefix, metadata={}, visibility='PRIVATE',

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -659,7 +659,7 @@ paths:
           schema:
             $ref: '#/definitions/Project'
       responses:
-        202:
+        201:
           description: Project details; at this point scene processes may be in-progress
           schema:
             $ref: '#/definitions/Project'
@@ -3075,6 +3075,7 @@ definitions:
             - DROPBOX
             - S3
             - LOCAL
+            - PLANET
         fileType:
           type: string
           description: type of data being uploaded, limited to two options right now


### PR DESCRIPTION
This adds initial support for creating uploads of planet imagery directly from the API.

To Test, obtain a planet API key and get a refresh token for Raster Foundry:

```import os
from rasterfoundry.api import API
from rasterfoundry.models import Project, Upload

org_id = 'dfac6307-b5ef-43f7-beda-b9f208bb7726'
datasource = '3d5b6e55-c9b7-4c86-b913-f45ae39296f7'
refresh_token = '<>'
planet_key = '<>'

api = API(refresh_token=refresh_token)
planet_ids = ['PSScene4Band:20170929_180204_0f35']
upload_create = Upload.upload_create_from_planet(
        datasource, org_id, planet_ids, project_id=project.id,
        metadata={'planetKey': planet_key}
)
upload = Upload.create(api, upload_create)
```

Verify that upload starts processing