### PR TITLE
Add method to post annotations for project

### DIFF
--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 from bravado.requests_client import RequestsClient
 from bravado.client import SwaggerClient
@@ -7,6 +8,7 @@ from simplejson import JSONDecodeError
 
 from .models import Project, MapToken
 from .exceptions import RefreshTokenException
+from .utils import mkdir_p
 
 SPEC_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                          'spec.yml')
@@ -146,11 +148,26 @@ class API(object):
                 self)
             image_uris = proj.get_image_source_uris()
             project_configs.append({
+                'id': project_id,
                 'images': image_uris,
                 'annotations': annotation_uri
             })
 
         return project_configs
 
+    def write_project_configs(self, project_ids, annotation_uris, output_path):
+        """Write project config file to disk.
+
+        This file is needed by Raster Vision to prepare training data, make
+        predictions, and evaluate predictions.
+
+        Args:
+            project_ids: list of project ids to make training data from
+            annotation_uris: list of corresponding annotation URIs
+            output_path: where to write the project config file
+        """
         project_configs = self.get_project_configs(
             project_ids, annotation_uris)
+        mkdir_p(os.path.dirname(output_path))
+        with open(output_path, 'w') as output_file:
+            json.dump(project_configs, output_file, sort_keys=True, indent=4)

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -1,5 +1,4 @@
 import os
-import uuid
 
 from bravado.requests_client import RequestsClient
 from bravado.client import SwaggerClient
@@ -8,8 +7,6 @@ from simplejson import JSONDecodeError
 
 from .models import Project, MapToken
 from .exceptions import RefreshTokenException
-from .utils import upload_raster_vision_config
-from .settings import RV_PROJ_CONFIG_DIR_URI
 
 SPEC_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                          'spec.yml')
@@ -155,101 +152,5 @@ class API(object):
 
         return project_configs
 
-    def start_prep_train_data_job(self, rv_batch_client, project_ids,
-                                  annotation_uris,
-                                  output_zip_uri, label_map_uri,
-                                  proj_config_dir_uri=RV_PROJ_CONFIG_DIR_URI,
-                                  min_area=None, single_label=None,
-                                  no_partial=True, channel_order=None):
-        """Start a Batch job to prepare object detection training data.
-
-        Args:
-            rv_batch_client: a RasterVisionBatchClient object used to start
-                Batch jobs
-            project_ids (list of str): ids of projects to make train data for
-            annotation_uris (list of str): annotation URIs for projects
-            output_zip_uri (str): URI of output zip file
-            label_map_uri (str): URI of output label map
-            proj_config_dir_uri (str): The root of generated URIs for config
-                files
-            min_area (float): minimum area of bounding boxes to include
-            single_label (str): Convert all labels to this label
-            no_partial (bool): Black out partially visible objects
-            channel_order: list of length 3 with GeoTIFF channel indices to
-                map to RGB.
-
-        Returns:
-            job_id (str): job_id of job started on Batch
-        """
         project_configs = self.get_project_configs(
             project_ids, annotation_uris)
-        config_uri = upload_raster_vision_config(
-            project_configs, proj_config_dir_uri)
-
-        base_command = \
-            'python -m rv.run prep_train_data --debug --chip-size 300 '
-        min_area_opt = ('--min-area {} '.format(min_area)
-                        if min_area is not None else '')
-        single_label_opt = ('--single-label {} '.format(single_label)
-                            if single_label is not None else '')
-        no_partial_opt = '--no-partial ' if no_partial else ''
-
-        channel_order_opt = ''
-        if channel_order is not None:
-            channel_order_str = ' '.join([
-                str(channel_ind) for channel_ind in channel_order])
-            channel_order_opt = ('--channel-order {} '
-                                 .format(channel_order_str))
-
-        command = (base_command + min_area_opt + single_label_opt +
-                   no_partial_opt + channel_order_opt + '{} {} {}')
-        command = command.format(config_uri, output_zip_uri, label_map_uri)
-
-        job_name = 'prep_train_data_{}'.format(uuid.uuid1())
-        job_id = rv_batch_client.start_raster_vision_job(job_name, command)
-        return job_id
-
-    def start_eval_model_job(self, rv_batch_client, inference_graph_uri,
-                             project_ids, annotation_uris, label_map_uri,
-                             output_uri,
-                             proj_config_dir_uri=RV_PROJ_CONFIG_DIR_URI,
-                             channel_order=None):
-        """Start a Batch job to evaluate a model using a set of projects.
-
-        Args:
-            rv_batch_client: a RasterVisionBatchClient object used to start
-                Batch jobs
-            project_ids (list of str): ids of projects to make train data for
-            annotation_uris (list of str): annotation URIs for projects
-            label_map_uri (str): URI of output label map
-            output_uri (str): URI of output zip file
-            proj_config_dir_uri (str): The root of generated URIs for config
-                files
-            channel_order: list of length 3 with GeoTIFF channel indices to
-                map to RGB.
-
-        Returns:
-            job_id (str): job_id of job started on Batch
-        """
-        project_configs = self.get_project_configs(
-            project_ids, annotation_uris)
-        projects_uri = upload_raster_vision_config(
-            project_configs, proj_config_dir_uri)
-
-        base_command = \
-            'python -m rv.run eval_model --chip-size 300 '
-
-        channel_order_opt = ''
-        if channel_order is not None:
-            channel_order_str = ' '.join([
-                str(channel_ind) for channel_ind in channel_order])
-            channel_order_opt = ('--channel-order {} '
-                                 .format(channel_order_str))
-
-        command = (base_command + channel_order_opt + '{} {} {} {}')
-        command = command.format(inference_graph_uri, projects_uri,
-                                 label_map_uri, output_uri)
-
-        job_name = 'eval_model_{}'.format(uuid.uuid1())
-        job_id = rv_batch_client.start_raster_vision_job(job_name, command)
-        return job_id

--- a/rasterfoundry/aws/s3.py
+++ b/rasterfoundry/aws/s3.py
@@ -2,7 +2,7 @@ from future.standard_library import install_aliases  # noqa
 install_aliases()  # noqa
 from urllib.parse import urlparse
 import json
-import StringIO
+import io
 
 import boto3
 from botocore.exceptions import ClientError
@@ -106,11 +106,11 @@ def download_to_string(uri):
     parsed_uri = urlparse(uri)
     if parsed_uri.scheme == 's3':
         try:
-            str_file = StringIO.StringIO()
+            file_buffer = io.BytesIO()
             s3.download_fileobj(
-                parsed_uri.netloc, parsed_uri.path[1:], str_file)
-            return str_file.getvalue()
+                parsed_uri.netloc, parsed_uri.path[1:], file_buffer)
+            return str(file_buffer.getvalue())
         finally:
-            str_file.close()
+            file_buffer.close()
     else:
         raise ValueError('uri needs to be for s3')

--- a/rasterfoundry/aws/s3.py
+++ b/rasterfoundry/aws/s3.py
@@ -1,4 +1,8 @@
+from future.standard_library import install_aliases  # noqa
+install_aliases()  # noqa
+from urllib.parse import urlparse
 import json
+import StringIO
 
 import boto3
 from botocore.exceptions import ClientError
@@ -96,3 +100,17 @@ def unauthorize_bucket(bucket_name):
         resp = {'ResponseMetadata': {'HTTPStatusCode': 204}}
 
     return resp['ResponseMetadata']['HTTPStatusCode']
+
+
+def download_to_string(uri):
+    parsed_uri = urlparse(uri)
+    if parsed_uri.scheme == 's3':
+        try:
+            str_file = StringIO.StringIO()
+            s3.download_fileobj(
+                parsed_uri.netloc, parsed_uri.path[1:], str_file)
+            return str_file.getvalue()
+        finally:
+            str_file.close()
+    else:
+        raise ValueError('uri needs to be for s3')

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -180,7 +180,8 @@ class Project(object):
         return source_uris
 
     def start_predict_job(self, rv_batch_client, inference_graph_uri,
-                          label_map_uri, predictions_uri):
+                          label_map_uri, predictions_uri,
+                          channel_order=[0, 1, 2]):
         """Start a Batch job to perform object detection on this project.
 
         Args:
@@ -190,21 +191,17 @@ class Project(object):
                 model file
             label_map_uri (str): file with mapping from class id to display name
             predictions_uri (str): GeoJSON file output by the prediction job
-            job_queue (str): name of the Batch job queue to run the job in
-            job_definition (str): name of the Batch job definition
-            branch_name (str): branch of the raster-vision repo to use
-            attempts (int): number of attempts for the Batch job
-
+            channel_order (list of int)
         Returns:
             job_id (str): job_id of job started on Batch
         """
         source_uris = self.get_image_source_uris()
         source_uris_str = ' '.join(source_uris)
-
+        channel_order = ' '.join([str(channel) for channel in channel_order])
         # Add uuid to job_name because it has to be unique.
         job_name = 'predict_project_{}_{}'.format(self.id, uuid.uuid1())
-        command = 'python -m rv.run predict {} {} {} {}'.format(
-            inference_graph_uri, label_map_uri, source_uris_str,
+        command = 'python -m rv.detection.run predict --channel-order {} {} {} {} {}'.format(  # noqa
+            channel_order, inference_graph_uri, label_map_uri, source_uris_str,
             predictions_uri)
         job_id = rv_batch_client.start_raster_vision_job(job_name, command)
 

--- a/rasterfoundry/settings.py
+++ b/rasterfoundry/settings.py
@@ -1,4 +1,4 @@
 RV_CPU_QUEUE = 'raster-vision-cpu'
 RV_CPU_JOB_DEF = 'raster-vision-cpu'
-RV_PROJ_CONFIG_DIR_URI = 's3://raster-vision-od/configs/projects'
+RV_PROJ_CONFIG_DIR_URI = 's3://raster-vision-lf-dev/detection/configs/projects/rf-generated'
 DEVELOP_BRANCH = 'develop'

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -82,6 +82,9 @@ x-resources:
   - name: Exports
     description: |
       Projects can be exported, but individual scenes and images cannot.
+  - name: Shapes
+    description: |
+      "Shapes are vectors that each user can create and manage. These shapes can then be used in various ways within the Raster Foundry platform."
 
 tags:
   - name: Users
@@ -610,6 +613,26 @@ paths:
             The UUID parameter does not refer to a scene or the user does not have access to the scene it refers to
           schema:
             $ref: '#/definitions/Error'
+  /scenes/{uuid}/download:
+    x-resource: Scenes
+    get:
+      summary: Get list of downloadable Images
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: An array of downloadable images. Each image has a `downloadUri` property.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ImageWithDownloadUri'
+        404:
+          description: |
+            UUID parameter does not refer to an scene or the user is not able to view the scene it refers to
+          schema:
+            $ref: '#/definitions/Error'
   /scene-grid/{zoom}/{column}/{row}/:
     x-resource: Scenes
     get:
@@ -738,17 +761,33 @@ paths:
           description: The UUID parameter does not refer to a project or the user does not have access to the project it refers to
           schema:
             $ref: '#/definitions/Error'
-
+  /projects/{uuid}/labels/:
+    x-resource: Projects
+    get:
+      summary: Get a list of the labels used on a project
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: A list of labels
+          schema:
+            type: array
+            items:
+              type: string
   /projects/{uuid}/annotations/:
     x-resource: Projects
     get:
-      summary: Get all annotations belonging to a project
+      summary: Get annotations belonging to a project
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
         - $ref: '#/parameters/AnnotationLabel'
         - $ref: '#/parameters/AnnotationQualityCheck'
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/pageSize'
       responses:
         200:
           description: GeoJSON feature collection containing paginated annotations of this project
@@ -756,7 +795,7 @@ paths:
             $ref: '#/definitions/AnnotationFeatureCollectionPaginated'
 
     post:
-      summary: Create annotations of this project
+      summary: Create annotations for a project
       tags:
         - Imagery
       parameters:
@@ -771,6 +810,19 @@ paths:
           description: GeoJSON annotations successfully created
           schema:
             $ref: '#/definitions/AnnotationFeatureCollection'
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete all annotations from a project
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        201:
+          description: Annotations Deleted
         default:
           description: Unexpected error.
           schema:
@@ -1674,6 +1726,8 @@ paths:
   /feed/:
     get:
       summary: Get the cached RSS feed
+      parameters:
+        - $ref: '#/parameters/source'
       tags:
         - Users
       responses:
@@ -1840,6 +1894,107 @@ paths:
             $ref: '#/definitions/Error'
         503:
           description: The request rate has been exceeded.
+          schema:
+            $ref: '#/definitions/Error'
+
+  /shapes/:
+    x-resource: Projects
+    get:
+      summary: Get shapes belonging to the current user
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/pageSize'
+      responses:
+        200:
+          description: GeoJSON feature collection containing paginated shapes
+          schema:
+            $ref: '#/definitions/ShapeFeatureCollectionPaginated'
+
+    post:
+      summary: Create shapes belonging to the current user
+      tags:
+        - Imagery
+      parameters:
+        - name: shapes
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ShapeFeatureCollectionCreate'
+      responses:
+        201:
+          description: GeoJSON shapes successfully created
+          schema:
+            $ref: '#/definitions/ShapeFeatureCollection'
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
+  /shapes/upload:
+    x-resource: Projects
+    post:
+      summary: Create shapes belonging to the current user using POSTed data
+      tags:
+        - Imagery
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: name
+          in: formData
+          type: file
+          required: true
+      responses:
+        201:
+          description: GeoJSON shapes successfully created
+          schema:
+            $ref: '#/definitions/ShapeFeatureCollection'
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
+  /shapes/{uuid}:
+    x-resouce: Projects
+    get:
+      summary: Get a specific shape
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: GeoJSON feature containing one shape
+          schema:
+            $ref: '#/definitions/ShapeFeature'
+
+    put:
+      summary: Update a specific shape
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: shape
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ShapeFeatureUpdate'
+      responses:
+        204:
+          description: No content, update successful
+
+    delete:
+      summary: Delete a shape
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: Deletion successful.
+        404:
+          description: The UUID parameter does not refer to a shape or the user does not have access to it.
           schema:
             $ref: '#/definitions/Error'
 
@@ -2220,6 +2375,12 @@ parameters:
       - COMPLETE
       - FAILED
       - ABORTED
+  source:
+    name: source
+    description: Feed source URI
+    in: query
+    type: string
+    required: false
 
 definitions:
   RenderDefinition:
@@ -2517,7 +2678,10 @@ definitions:
     properties:
       id_token:
         type: string
-        description: JSON Web Token that can be used for authenticating API requests
+        description: Token that can be used for authenticating API requests
+      access_token:
+        type: string
+        description: Token that can be used for authenticating API requests
       token_type:
         type: string
         description: Type of token returned by using the refresh token
@@ -2626,10 +2790,7 @@ definitions:
           enum:
             - MultiPolygon
             - Polygon
-            - MultiLineString
-            - LineString
-            - MuliPoint
-            - Point
+            - Point2D
           description: the geometry type
   Point2D:
       type: array
@@ -2653,6 +2814,20 @@ definitions:
                   type: array
                   items:
                     $ref: '#/definitions/Point2D'
+  Polygon:
+    type: object
+    description: GeoJSON geometry
+    externalDocs:
+      url: https://tools.ietf.org/html/rfc7946#section-3.1
+    allOf:
+      - $ref: "#/definitions/Geometry"
+      - properties:
+          coordinates:
+            type: array
+            items:
+              type: array
+              items:
+                $ref: '#/definitions/Point2D'
   Composite:
     type: object
     description: mapping of bands to RGB
@@ -2924,6 +3099,57 @@ definitions:
           description: |
             Metadata files that should be present for processing all
             images in a scene (e.g. relevant .mtl files or .xml)
+      required:
+        - filename
+        - sourceUri
+  ImageWithDownloadUri:
+    allOf:
+    - $ref: '#/definitions/BaseModel'
+    - $ref: '#/definitions/UserTrackingMixin'
+    - type: object
+      properties:
+        visibility:
+          type: string
+          description: Level of restriction on viewing
+          enum:
+            - PUBLIC
+            - ORGANIZATION
+            - PRIVATE
+        filename:
+          type: string
+          description: Name of the image file
+        resolutionMeters:
+          type: number
+          description: Size of pixel in meters
+        sourceUri:
+          type: string
+          description: URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.
+        rawDataBytes:
+          type: integer
+          format: int64
+          description: Size of original uploaded imagery in bytes
+        bands:
+          type: array
+          description: list of band types for image; a single band denotes a single band image, multiple bands should be listed in order (e.g if it is an RGB tiff then bands should be [red, green blue])
+          items:
+            $ref: '#/definitions/Band'
+        scene:
+          type: string
+          format: uuid
+          description: Scene that image is associated with
+        image_metadata:
+          type: object
+          description: Metadata about this image
+        metadataFiles:
+          type: array
+          items:
+            type: string
+          description: |
+            Metadata files that should be present for processing all
+            images in a scene (e.g. relevant .mtl files or .xml)
+        downloadUri:
+          type: string
+          description: URI to downloadable resource. This is not always the same as `sourceUri`.
       required:
         - filename
         - sourceUri
@@ -3613,7 +3839,7 @@ definitions:
           confidence:
             type: number
             format: float
-          qualityCheck:
+          quality:
             type: string
             enum:
               - YES
@@ -3643,7 +3869,7 @@ definitions:
           confidence:
             type: number
             format: float
-          qualityCheck:
+          quality:
             type: string
             enum:
               - YES
@@ -3672,7 +3898,7 @@ definitions:
           confidence:
             type: number
             format: float
-          qualityCheck:
+          quality:
             type: string
             enum:
               - YES
@@ -3714,3 +3940,86 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/AnnotationFeatureCreate'
+  ShapeFeature:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        allOf:
+        - $ref: '#/definitions/BaseModel'
+        - $ref: '#/definitions/TimeModelMixin'
+        - $ref: '#/definitions/UserTrackingMixin'
+        - type: object
+        properties:
+          name:
+            type: string
+          description:
+            type: string
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  ShapeFeatureUpdate:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        type: object
+        properties:
+          name:
+            type: string
+          description:
+            type: string
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  ShapeFeatureCreate:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        allOf:
+        - $ref: '#/definitions/BaseCreate'
+        - type: object
+        properties:
+          name:
+            type: string
+          description:
+            type: string
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  ShapeFeatureCollection:
+    type: object
+    properties:
+      type:
+        type: string
+      features:
+        type: array
+        items:
+          $ref: '#/definitions/ShapeFeature'
+
+  ShapeFeatureCollectionPaginated:
+    type: object
+    allOf:
+      - $ref: '#/definitions/PaginatedResponse'
+      - type: object
+        properties:
+          type:
+            type: string
+          features:
+            type: array
+            items:
+              $ref: '#/definitions/ShapeFeature'
+
+  ShapeFeatureCollectionCreate:
+    type: object
+    properties:
+      type:
+        type: string
+      features:
+        type: array
+        items:
+          $ref: '#/definitions/ShapeFeatureCreate'

--- a/rasterfoundry/utils.py
+++ b/rasterfoundry/utils.py
@@ -5,6 +5,8 @@ from os.path import join
 import tempfile
 import uuid
 import json
+import os
+import errno
 
 import boto3
 
@@ -78,3 +80,13 @@ def upload_raster_vision_config(config_dict, config_uri_root):
             config_file.name, parsed_uri.netloc, parsed_uri.path[1:])
 
         return config_uri
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise


### PR DESCRIPTION
This PR adds a method to posts annotations for a project that are stored in a JSON file on S3. This will be called by the Lambda function in https://github.com/azavea/raster-foundry-deployment/pull/115. This also makes some other changes to stay in sync with the latest RV and removes some methods which are not useful and annoying to maintain.

To test making a prediction, run the following commands:
```
from rasterfoundry.api import API
token = 'XXX'
api = API(refresh_token=token)

from rasterfoundry.utils import RasterVisionBatchClient

rv_batch_client = RasterVisionBatchClient(
    branch_name='lf/rfint', job_queue='raster-vision-cpu',
    job_definition='raster-vision-cpu')

from rasterfoundry.models.project import Project

uuid = 'de3780a1-9f3e-4fa3-a811-ad3060b64866'
proj = api.client.Imagery.get_projects_uuid(uuid=uuid).result()
proj = Project(proj, api)

inference_graph_uri = 's3://raster-vision-lf-dev/detection/trained-models/cowc-potsdam/5cm/inference-graph.pb'
label_map_uri = 's3://raster-vision-lf-dev/detection/configs/label-maps/cowc.pbtxt'
predictions_uri = 's3://raster-vision-lf-dev/detection/predictions/cowc-potsdam/5cm/de3780a1-9f3e-4fa3-a811-ad3060b64866.json'

proj.start_predict_job(rv_batch_client, inference_graph_uri, label_map_uri,
                       predictions_uri, channel_order=[0, 1, 2])
```

To test posting predictions, run the following after clearing the annotations in the UI at https://app.rasterfoundry.com/projects/edit/de3780a1-9f3e-4fa3-a811-ad3060b64866/annotate
```
proj.post_annotations(predictions_uri)
```

Connect #41 
