### PR TITLE
[WIP] Include export and visualization examples with analyses

### DIFF
--- a/examples/Analyses.ipynb
+++ b/examples/Analyses.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting analyses from the client"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -21,7 +28,21 @@
    "source": [
     "analyses = api.analyses\n",
     "analysis = analyses[0]\n",
-    "analyses"
+    "analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing analyses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing to projects"
    ]
   },
   {
@@ -37,25 +58,157 @@
     "project.compare(analysis, m)\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exporting analyses using tile layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import DrawControl\n",
+    "dc = DrawControl()\n",
+    "\n",
+    "m = analysis.get_map()\n",
+    "m.add_control(dc)\n",
+    "analysis.add_to(m)\n",
+    "m\n",
+    "\n",
+    "# Draw a polygon on the map below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "last_draw = dc.last_draw\n",
+    "last_draw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate a bounding box from the last draw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def snap_to_360(x_coord):\n",
+    "    \"\"\"Snap an x coordinate to [-180, 180]\n",
+    "    \n",
+    "    Coordinates coming back from the API for some projects can be\n",
+    "    outside this range, and coordinates in the bbox outside this\n",
+    "    range make the export API upset. When it's upset, it returns\n",
+    "    an array with just a single 0 in it, which is not an accurate\n",
+    "    representation of the project normally.\n",
+    "    \"\"\"\n",
+    "    return x_coord - round((x_coord + 180) / 360, 0) * 360\n",
+    "\n",
+    "def geom_to_bbox(geom):\n",
+    "    coords = geom['geometry']['coordinates'][0]\n",
+    "    min_x = snap_to_360(min([point[0] for point in coords]))\n",
+    "    min_y = min([point[1] for point in coords])\n",
+    "    max_x = snap_to_360(max([point[0] for point in coords]))\n",
+    "    max_y = max([point[1] for point in coords])\n",
+    "    return ','.join(map(str, [min_x, min_y, max_x, max_y]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "bbox = geom_to_bbox(last_draw)\n",
+    "bbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Request a synchronous export for our area "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = analysis.get_export(bbox=bbox)\n",
+    "resp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualize the export\n",
+    "\n",
+    "If you don't have rasterio or matplotlib installed, you can run the cell at the bottom of this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterio.io import MemoryFile\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "data = resp.content\n",
+    "with MemoryFile(data) as memfile:\n",
+    "    with memfile.open() as dataset:\n",
+    "        plt.imshow(dataset.read(1), cmap='Purples')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "pip install numpy matplotlib rasterio==1.0a12"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -203,7 +203,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "pip install numpy matplotlib rasterio==1.0a8"
+    "pip install numpy matplotlib rasterio==1.0a12"
    ]
   }
  ],


### PR DESCRIPTION
Overview
-----

This PR adds examples of export and viz functionality to the analyses notebook.

Specifically, it includes an example of, once you have an analysis,

- adding that analysis to a map
- fetching an export from a bbox drawn on that map
- visualizing that export

Testing
-----

- get a token
- point your api client in the `examples/Analyses.ipynb` notebook to staging (I don't know if this is necessary but I think it's safer maybe)
- run through the analyses notebook

Closes #45, or at least the revised version of #45 from slack discussion :man_shrugging:  