### PR TITLE
Point to user-configable swagger spec location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,17 @@ Usage
    # Get TMS URl without token
    one_project.tms()
 
+Versions
+~~~~~~~~
+
+The latest version of `rasterfoundry` always points to the most recently released swagger spec in
+the raster-foundry/raster-foundy-api-spec repository. If you need to point to a different spec
+version, either install a version of the python client that refers to the appropriate spec, or
+set the `RF_API_SPEC_PATH` environment variable to a url or local file path pointing to the
+version of the spec that you want to use.
+
+Generally this shouldn't matter, because the Raster Foundry API shouldn't have breaking changes.
+
 
 Installation
 ------------

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -1,19 +1,27 @@
-import os
 import json
+import os
 import uuid
 
-from bravado.requests_client import RequestsClient
 from bravado.client import SwaggerClient
-from bravado.swagger_model import load_file
+from bravado.requests_client import RequestsClient
+from bravado.swagger_model import load_file, load_url
 from simplejson import JSONDecodeError
 
-from .models import Project, MapToken, Analysis
-from .exceptions import RefreshTokenException
 from .aws.s3 import str_to_file
+from .exceptions import RefreshTokenException
+from .models import Analysis, MapToken, Project
 from .settings import RV_TEMP_URI
 
-SPEC_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                         'spec.yml')
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+
+SPEC_PATH = os.getenv(
+    'RF_API_SPEC_PATH',
+    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/master/spec.yml'
+)
 
 
 class API(object):
@@ -34,7 +42,10 @@ class API(object):
         self.http = RequestsClient()
         self.scheme = scheme
 
-        spec = load_file(SPEC_PATH)
+        if urlparse(SPEC_PATH).netloc:
+            spec = load_url(SPEC_PATH)
+        else:
+            spec = load_file(SPEC_PATH)
 
         spec['host'] = host
         spec['schemes'] = [scheme]


### PR DESCRIPTION
Overview
-----

This PR makes it so users can point to a specific swagger spec if they need to, otherwise it just points
to `master` on the raster-foundry/raster-foundry-api-spec repo. Once we have a release of that, it
can point to a specific release.

Testing
-----

- add a print to either the `load_url` or `load_file` branch of the api client initialization
- start an ipython session with no special environment variables
- create a client
- verify that your print either did or didn't happen
- call `.projects` on the client you created and verify it works
- start an ipython session with `RF_API_SPEC_PATH` set to `rasterfoundry/spec.yml`
- create a client
- verify that your print either did or didn't happen
- call `.projects` on the client you created and verify it works

Closes #48 