### PR TITLE
Support async exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ENV/
 /site
 /.idea/
 /raster-foundry-python-client.iml
+
+# MacOS
+.DS_Store

--- a/examples/Analyses.ipynb
+++ b/examples/Analyses.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting analyses from the client"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -21,7 +28,21 @@
    "source": [
     "analyses = api.analyses\n",
     "analysis = analyses[0]\n",
-    "analyses"
+    "analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing analyses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing to projects"
    ]
   },
   {
@@ -37,25 +58,157 @@
     "project.compare(analysis, m)\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exporting analyses using tile layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import DrawControl\n",
+    "dc = DrawControl()\n",
+    "\n",
+    "m = analysis.get_map()\n",
+    "m.add_control(dc)\n",
+    "analysis.add_to(m)\n",
+    "m\n",
+    "\n",
+    "# Draw a polygon on the map below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "last_draw = dc.last_draw\n",
+    "last_draw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate a bounding box from the last draw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def snap_to_360(x_coord):\n",
+    "    \"\"\"Snap an x coordinate to [-180, 180]\n",
+    "    \n",
+    "    Coordinates coming back from the API for some projects can be\n",
+    "    outside this range, and coordinates in the bbox outside this\n",
+    "    range make the export API upset. When it's upset, it returns\n",
+    "    an array with just a single 0 in it, which is not an accurate\n",
+    "    representation of the project normally.\n",
+    "    \"\"\"\n",
+    "    return x_coord - round((x_coord + 180) / 360, 0) * 360\n",
+    "\n",
+    "def geom_to_bbox(geom):\n",
+    "    coords = geom['geometry']['coordinates'][0]\n",
+    "    min_x = snap_to_360(min([point[0] for point in coords]))\n",
+    "    min_y = min([point[1] for point in coords])\n",
+    "    max_x = snap_to_360(max([point[0] for point in coords]))\n",
+    "    max_y = max([point[1] for point in coords])\n",
+    "    return ','.join(map(str, [min_x, min_y, max_x, max_y]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "bbox = geom_to_bbox(last_draw)\n",
+    "bbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Request a synchronous export for our area "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = analysis.get_export(bbox=bbox)\n",
+    "resp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualize the export\n",
+    "\n",
+    "If you don't have rasterio or matplotlib installed, you can run the cell at the bottom of this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterio.io import MemoryFile\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "data = resp.content\n",
+    "with MemoryFile(data) as memfile:\n",
+    "    with memfile.open() as dataset:\n",
+    "        plt.imshow(dataset.read(1), cmap='Purples')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "pip install numpy matplotlib rasterio==1.0a12"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Analyses.ipynb
+++ b/examples/Analyses.ipynb
@@ -144,26 +144,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Request a synchronous export for our area "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resp = analysis.get_export(bbox=bbox)\n",
-    "resp"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Visualize the export\n",
+    "### Export as GeoTIFF\n",
     "\n",
-    "If you don't have rasterio or matplotlib installed, you can run the cell at the bottom of this notebook"
+    "Note: this example requires\n",
+    "[`numpy`](http://www.numpy.org/),\n",
+    "[`matplotlib`](http://matplotlib.org/), and a fairly recent version of\n",
+    "[`rasterio`](https://mapbox.github.io/rasterio/).\n",
+    "\n",
+    "If you don't have them, you can run the cell at the bottom of this notebook,\n",
+    "provided your pip installation directory is writable."
    ]
   },
   {
@@ -175,10 +164,34 @@
     "from rasterio.io import MemoryFile\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "data = resp.content\n",
-    "with MemoryFile(data) as memfile:\n",
+    "thumbnail = analysis.get_thumbnail(bbox=bbox, zoom=8)\n",
+    "\n",
+    "with MemoryFile(thumbnail) as memfile:\n",
     "    with memfile.open() as dataset:\n",
-    "        plt.imshow(dataset.read(1), cmap='Purples')"
+    "        plt.imshow(dataset.read(1), cmap='RdBu')\n",
+    "        \n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Request an asynchronous export\n",
+    "\n",
+    "Asynchronous export is good when you have a large analysis or bounding box, or when you need a high\n",
+    "zoom level in the resulting geotiff. Creating an asynchronous export requires only a\n",
+    "bbox and zoom level for this analysis. Created exports run remotely. For examples of what\n",
+    "you can do with exports, check out the [Exports](./Export.ipynb) notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "export = analysis.create_export(bbox=bbox, zoom=13)"
    ]
   },
   {
@@ -208,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Analyses.ipynb
+++ b/examples/Analyses.ipynb
@@ -208,7 +208,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/examples/Export.ipynb
+++ b/examples/Export.ipynb
@@ -125,24 +125,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = project_export.download_file()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.content"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -166,9 +148,9 @@
     "from rasterio.io import MemoryFile\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "data = project_export.download_file()\n",
+    "data = project_export.download_file_bytes()\n",
     "\n",
-    "with MemoryFile(data.content) as memfile:\n",
+    "with MemoryFile(data) as memfile:\n",
     "    with memfile.open() as dataset:\n",
     "        plt.imshow(dataset.read(1), cmap='viridis')\n",
     "        \n",

--- a/examples/Export.ipynb
+++ b/examples/Export.ipynb
@@ -11,13 +11,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from rasterfoundry.api import API\n",
-    "refresh_token = '<your_refresh_token>'\n",
+    "refresh_token = '<your refresh token>'\n",
     "api = API(refresh_token=refresh_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api.projects"
    ]
   },
   {
@@ -36,43 +45,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dedd95f0273e424bb7b442b2992bd7ba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>Map</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
-      "text/plain": [
-       "Map(center=[37.4398765951139, 283.35567345891246], controls=(DrawControl(layer=FeatureGroup(), polygon={'shapeOptions': {}}, polyline={'shapeOptions': {}}),), layers=(TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'), TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://tiles.staging.rasterfoundry.com/tiles/982520bf-16fe-42e8-9d5e-c786004fbbed/{z}/{x}/{y}/?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFUZEdSakZCTkVSQ1FqVkNRamxHUmpRMk0wSTFSRFZFTkRjME1EazVPVU01TkRRNU1qWXhOZyJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LXN0Zy5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMDQ5Mzg4OTE2NDUwMzk3NDAyNTEiLCJhdWQiOiJGU21UdmNFdzRReUdDOHA1QktIREN1Y2dJZldSS3VoRSIsImlhdCI6MTUyMDM3MzQyMSwiZXhwIjoxNTIwNDA5NDIxfQ.eBmhxY4FfXu_Usmz8pF-aiGYrfH0vznGJB9SOObPTbKfc01CSwtrvWZdbnNsWHjlNmh3oOgwp-8FV_uUjOgl1NLFYaX429HKFo06O_11PORXgfLf4iu5As7ecFeVOaUOETIUZL0CqAHiBvGxwep0HH3Aef27HraweQl6opae5aSlHovMqoWEpNILpzg7GjEnFUOgIt0ooUUxmEcY-pauuZ0-17DPoJoBtnfx6vNEYtsX0Qen-Xo5zlzemuOaHdqozmc2c31PKQL-xcpg4YJK9Nihzpx4s0YlTXG3UD5pZYTKFSSbavhoBW_WJpM1LIOSWii-9-znJsJp1rzyhU6zJA')), layout=Layout(align_self=u'stretch', height=u'400px'), options=[u'keyboard_pan_offset', u'tap', u'attribution_control', u'max_zoom', u'min_zoom', u'bounce_at_zoom_limits', u'keyboard', u'scroll_wheel_zoom', u'dragging', u'inertia_max_speed', u'close_popup_on_click', u'zoom_control', u'box_zoom', u'double_click_zoom', u'tap_tolerance', u'zoom_start', u'keyboard_zoom_offset', u'inertia_deceleration', u'inertia', u'center', u'zoom', u'world_copy_jump', u'zoom_animation_threshold', u'touch_zoom'], scroll_wheel_zoom=True)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ipyleaflet import DrawControl\n",
     "\n",
-    "project = api.projects[-1]\n",
+    "project = api.projects[4]\n",
     "m = project.get_map()\n",
     "\n",
     "dc = DrawControl()\n",
@@ -85,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,20 +115,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "u'EXPORTED'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "completed_export = project_export.wait_for_completion()\n",
     "# it will say 'EXPORTED' as the output of this block if the export is finished\n",
@@ -157,100 +125,71 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Download the export to memory"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests\n",
-    "\n",
-    "f_names = api.client.Imagery.get_exports_uuid_files(uuid=project_export.id).result()\n",
-    "f_name = filter(lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(), f_names)[0]\n",
-    "\n",
-    "url = 'https://app.staging.rasterfoundry.com/api/exports/{export_id}/files/{file_name}'.format(export_id=project_export.id, file_name=f_name)\n",
-    "params = {'token': api.api_token}\n",
-    "\n",
-    "export_resp = requests.get(url=url, params=params)"
+    "data = project_export.download_file()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.content"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plot the expot"
+    "### Download and plot the export\n",
+    "\n",
+    "Note: this example requires\n",
+    "[`numpy`](http://www.numpy.org/),\n",
+    "[`matplotlib`](http://matplotlib.org/), and a fairly recent version of\n",
+    "[`rasterio`](https://mapbox.github.io/rasterio/).\n",
+    "\n",
+    "If you don't have them, you can run the cell at the bottom of this notebook,\n",
+    "provided your pip installation directory is writable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: numpy in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages\n",
-      "Requirement already satisfied: matplotlib in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages\n",
-      "Requirement already satisfied: rasterio==1.0a12 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages\n",
-      "Requirement already satisfied: subprocess32 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: backports.functools-lru-cache in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: cycler>=0.10 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: pytz in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: python-dateutil>=2.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: six>=1.10 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
-      "Requirement already satisfied: enum34 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
-      "Requirement already satisfied: cligj in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
-      "Requirement already satisfied: affine in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
-      "Requirement already satisfied: click-plugins in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
-      "Requirement already satisfied: attrs in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
-      "Requirement already satisfied: snuggs>=1.4.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
-      "Requirement already satisfied: setuptools in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from kiwisolver>=1.0.1->matplotlib)\n",
-      "Requirement already satisfied: click>=4.0 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from cligj->rasterio==1.0a12)\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash\n",
-    "pip install numpy matplotlib rasterio==1.0a12\n",
-    "# Install numpy matplotlib for plot to work"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARQAAAD8CAYAAAC2EFsiAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvFvnyVgAAElFJREFUeJzt3X+s1Xd9x/Hn69wfgG3lR8sIa6tFRRtcJlbW0miWTlOKbBk1MYZmWW8qCW5rE82WTZjJqtYluky7NdEqrp1oVMr8kd40dezamiz7o5RSEYGKXNs622BpvZTCinB/vPfH933xjF3g3Hs/955zD69HcnK/38/3e8/5fgi8ON/v+fFSRGBmVkKt2QdgZu3DgWJmxThQzKwYB4qZFeNAMbNiHChmVsy0B4qk1ZIOSOqXtHG6H9/Mpo6m830okjqAnwI3As8BO4FbImL/tB2EmU2Z6X6Gci3QHxFPR8QpYCuwdpqPwcymSOc0P97lwC/q1p8DrqvfQdIGYAPARRdd9I6r33L19B2d2QVo15O7XoqIhSXua7oD5bwiYjOwGWDFO1bEjh2PN/mIzNpbZ1fHz0vd13Sf8jwPXFm3fkWOmVkbmO5A2QkslbREUjewDuid5mMwsykyrac8ETEk6Q5gO9AB3B8R+6bzGMxs6kz7NZSIeBh4eLof18ymnt8pa2bFOFDMrBgHipkV40Axs2IcKGZWjAPFzIpxoJhZMQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysmEkFiqRnJf1Y0m5JT+TYAkl9kg7mz/k5Lkn3ZAXpHknXlJiAmbWOEs9Q/iAilkfEilzfCDwSEUuBR3Id4L3A0rxtAO4t8Nhm1kKm4pRnLbAll7cAN9eNfzUqjwHzJC2egsc3syaZbKAE8B+SdmWFKMCiiDiUy78EFuXyWDWkl0/y8c2shUy2RuNdEfG8pN8C+iT9pH5jRISkGM8d1ncbv+51r5vk4ZnZdJrUM5SIeD5/Hga+C1wLvDB6KpM/D+fuDdWQRsTmiFgRESsWXlakv9nMpsmEA0XSRZIuGV0GVgF7qapFe3K3HuDBXO4Fbs1Xe1YCR+tOjcysDUzmlGcR8F1Jo/fzjYj4d0k7gW2S1gM/Bz6Q+z8MrAH6gVeB2ybx2GbWgiYcKBHxNPC2McZ/BbxnjPEAbp/o45lZ6/M7Zc2sGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkV40Axs2IcKGZWjAPFzIpxoJhZMQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNizhsoku6XdFjS3rqxcfcXS+rJ/Q9K6hnrscxsZmvkGcpXgNVnjI2rv1jSAuBO4Dqq7p47R0PIzNrHeQMlIv4TGDhjeLz9xTcBfRExEBFHgD7+f0iZ2Qw30Wso4+0vbrjXWNIGSU9IeuLFl16c4OGZWTNM+qJs9u2Mq7/4PPfnKlKzGWqigTLe/uKGeo3NbGabaKCMt794O7BK0vy8GLsqx8ysjZy3ilTSN4EbgMskPUf1as2nGUd/cUQMSLoL2Jn7fTIizrzQa2YznKpLIK1pxTtWxI4djzf7MMzaWmdXx66IWFHivvxOWTMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkVc95PG5u1g+PHT/LfvzjK66+cy8GnB3jzGy9FghO/HmJwcJi5r53N8MgIXZ0dBCCge5b/eYyXn6HYBUHAlZe/lsHBYd7ypkt5aeBVajUxZ04n8+bNQTXR0eF/DpPlP0G7IAwNjVCriVmzOxkZCebPnc2JE4PECJw4MciRI1XAtO6XecwMDhS7IBw7forBwWGGBkcYGQm6ujvo7u5Egs4OMX/eHAYHhyG/H8jBMjEOFLsgzJs7i46OGp1dNSKC4eERRkZGADh1ahhJdHZ2MBKBmnysM5kDxS4ItVqNWk0MDY7Q0Vmjo1ZjeDhQTRw7forRby6sqYqTkeGRZh7ujDXRKtKPS3pe0u68ranbtimrSA9IuqlufHWO9UvaeObjmE0l1aCzs1aFx0gwMhLUauLkr4dYeNlFnP4mVFXXUWo1P0+ZiIlWkQLcHRHL8/YwgKRlwDrgrfk7X5DUIakD+DxVVeky4Jbc12xavPLKSUYiePGl/2F4OPj1ySGGh0eYPbuTU6eGQDB4auj0/sPDvooyEROtIj2btcDWiDgZEc9Qffv9tXnrj4inI+IUsDX3NZsWXV0djIwEr79yLlC9jDx7Theqide8pptjx05WO+ZTFfkJyoRM5hrKHZL25CnRaPG5q0itJc3q7oCAWbM76eis0dlZ48Srgxw7dpIXXjzOqycG6er+zRvZan5PyoRM9K2A9wJ3Ub26dhfwWeCDJQ4oIjYDm6Gq0Shxn2YXXTzrrNsuncbjaHcTCpSIeGF0WdKXgYdy9VyVo64iNWtzE3peN9prnN4HjL4C1AuskzRL0hJgKfA4VWPgUklLJHVTXbjtnfhhm1krmmgV6Q2SllOd8jwLfAggIvZJ2gbsB4aA2yNiOO/nDqo+4w7g/ojYV3w2ZtZUriI1u8C5itTMWpIDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkV40Axs2IcKGZWjAPFzIpppIr0Skk/kLRf0j5JH87xBZL6JB3Mn/NzXJLuycrRPZKuqbuvntz/oKSeqZuWmTVDI89QhoC/iohlwErg9qwR3Qg8EhFLgUdyHaq60aV520DV4YOkBVRfcH0dVZPgnXUFYWbWBhqpIj0UEU/m8jHgKarWv7XAltxtC3BzLq8FvhqVx4B5WbtxE9AXEQMRcQToY+zOZDObocZ1DUXSVcDbgR3Aoog4lJt+CSzK5UnVkbqK1GzmajhQJF0MfBv4SES8Ur8tqi6OIn0cEbE5IlZExIqFly0scZdmNk0aChRJXVRh8vWI+E4OvzDaIJg/D+f42epIz1VTamZtoJFXeQTcBzwVEZ+r29QLjL5S0wM8WDd+a77asxI4mqdG24FVkubnxdhVOWZmbaKRsvR3An8K/FjS7hz7W+DTwDZJ64GfAx/IbQ8Da4B+4FXgNoCIGJB0F1XPMcAnI2KgyCzMrCW4itTsAucqUjNrSQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK2YyVaQfl/S8pN15W1P3O5uyivSApJvqxlfnWL+kjWM9npnNXI18SfVoFemTki4Bdknqy213R8Q/1u+cNaXrgLcCvw18X9Kbc/PngRupSr52SuqNiP0lJmJmzXfeQMkKjEO5fEzSaBXp2awFtkbESeAZSf1UXcYA/RHxNICkrbmvA8WsTUymihTgDkl7JN1fV3zuKlKzC9RkqkjvBd4ILKd6BvPZEgfkKlKzmauRayhjVpFGxAt1278MPJSr56ocdRWpWRubcBXpaK9xeh+wN5d7gXWSZklaAiwFHqdqDFwqaYmkbqoLt71lpmFmrWAyVaS3SFoOBPAs8CGAiNgnaRvVxdYh4PaIGAaQdAdVn3EHcH9E7Cs4FzNrMleRml3gXEVqZi3JgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFNPIl1bMlPS7pR1lF+okcXyJpR9aKPpBfPE1+OfUDOb4ju3xG72vMilIzaw+NPEM5Cbw7It5G1cGzWtJK4DNUVaRvAo4A63P/9cCRHL879zuzonQ18AVJHSUnY2bNdd5AicrxXO3KWwDvBr6V41uAm3N5ba6T29+TVRynK0oj4hmgvqLUzNpAQ9dQJHVkhcZhoA/4GfByRAzlLvW1oqcrR3P7UeBSXEVq1vYaCpSIGI6I5VRtf9cCV0/VAbmK1GzmGterPBHxMvAD4HpgnqTRorD6WtHTVaS5fS7wK85dUWpmbaCRV3kWSpqXy3OAG4GnqILl/blbD/BgLvfmOrn90ajaxM5WUWpmbaKRKtLFwJZ8RaYGbIuIhyTtB7ZK+hTwQ6r+Y/Ln1yT1AwNUr+ycs6LUzNqDq0jNLnCuIjWzluRAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkV40Axs2ImU0X6FUnPSNqdt+U5Lkn3ZOXoHknX1N1Xj6SDees522Oa2czUyJdUj1aRHpfUBfyXpO/ltr+OiG+dsf97qb7RfilwHXAvcJ2kBcCdwAqq5sFdknoj4kiJiZhZ802mivRs1gJfzd97jKq/ZzFwE9AXEQMZIn1UHcdm1iYmVEUaETty09/nac3dkmbl2NkqRxuqIjWzmWtCVaSSfgfYRFVJ+nvAAuCjJQ7I3cZmM9dEq0hXR8ShPK05CfwrVecxnL1ytKEqUncbm81cE60i/UleF0GSgJuBvfkrvcCt+WrPSuBoRBwCtgOrJM2XNB9YlWNm1iYmU0X6qKSFgIDdwJ/l/g8Da4B+4FXgNoCIGJB0F7Az9/tkRAyUm4qZNZurSM0ucK4iNbOW5EAxs2IcKGZWjAPFzIpxoJhZMQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlZMw4GSZV8/lPRQri+RtCM7jB+Q1J3js3K9P7dfVXcfm3L8gKSbSk/GzJprPM9QPgw8Vbf+GeDuiHgTcARYn+PrgSM5fnfuh6RlwDrgrVQVpF/Ib9I3szbRaBXpFcAfAv+S6wLeDYwWpW+h6uaBqtt4Sy5/C3hP7r8W2BoRJyPiGaqajdFyMDNrA4308gD8E/A3wCW5finwckQM5Xp9T/HpDuOIGJJ0NPe/HHis7j7H7DaWtAHYkKsnO7s69p65T5u4DHip2QcxBdp1XtC+c3tLqTs6b6BI+iPgcETsknRDqQc+m4jYDGzOx36iVF9Iq2nXubXrvKB95ybpiVL31cgzlHcCfyxpDTAbeC3wz8A8SZ35LKW+p3i0w/g5SZ3AXOBXNNhtbGYz13mvoUTEpoi4IiKuorqo+mhE/AlVafr7c7ce4MFc7s11cvujUdUT9gLr8lWgJcBSwLWAZm2k0WsoY/kosFXSp4AfAvfl+H3A1yT1AwNUIURE7JO0DdgPDAG3R8TweR5j8ySOr9W169zadV7QvnMrNq+W7jY2s5nF75Q1s2IcKGZWTMsGiqTV+Rb9fkkbm3085yPpfkmHJe2tG1sgqU/Swfw5P8cl6Z6c2x5J19T9Tk/uf1BSz1iPNZ0kXSnpB5L2S9on6cM53g5zmy3pcUk/yrl9Isfb4mMlTfm4TES03A3oAH4GvAHoBn4ELGv2cZ3nmH8fuAbYWzf2D8DGXN4IfCaX1wDfAwSsBHbk+ALg6fw5P5fnN3lei4FrcvkS4KfAsjaZm4CLc7kL2JHHvA1Yl+NfBP48l/8C+GIurwMeyOVl+Xd0FrAk/+52tMDfyb8EvgE8lOtTPq+mTvgcfxDXA9vr1jcBm5p9XA0c91VnBMoBYHEuLwYO5PKXgFvO3A+4BfhS3fj/2a8VblRvD7ix3eYGvAZ4EriO6t2wnWf+XQS2A9fncmfupzP/ftbv18T5XAE8QvURmYfyOKd8Xq16ynP67ftpzLfpzwCLIuJQLv8SWJTLZ5tfS887nwq/nep/8raYW54W7AYOA31U/ws39LESoP5jJa02t9GPy4zkesMfl2ES82rVQGk7UUX8jH2NXtLFwLeBj0TEK/XbZvLcImI4IpZT/Y9+LXB1kw9p0uo/LjPdj92qgdIub9N/QdJigPx5OMfPNr+WnLekLqow+XpEfCeH22JuoyLiZap3f19PfqwkN431sRJa/GMlox+XeRbYSnXac/rjMrnPlMyrVQNlJ7A0r0p3U10o6m3yMU1E/ccQzvx4wq35ishK4GiePmwHVkman6+arMqxpsmvnrgPeCoiPle3qR3mtlDSvFyeQ3Vt6Clm+MdKopkfl2n2xbBzXFRaQ/WKws+AjzX7eBo43m8Ch4BBqnPN9VTnoY8AB4HvAwtyXwGfz7n9GFhRdz8fpPqumH7gthaY17uoTmf2ALvztqZN5va7VB8b2QPsBf4ux9+Q/3D6gX8DZuX47Fzvz+1vqLuvj+WcDwDvbfbc6o7rBn7zKs+Uz8tvvTezYlr1lMfMZiAHipkV40Axs2IcKGZWjAPFzIpxoJhZMQ4UMyvmfwGjtnOG2iAVcQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from rasterio.io import MemoryFile\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "data = export_resp.content\n",
+    "data = project_export.download_file()\n",
     "\n",
-    "with MemoryFile(data) as memfile:\n",
+    "with MemoryFile(data.content) as memfile:\n",
     "    with memfile.open() as dataset:\n",
-    "        plt.imshow(dataset.read(1), cmap='Purples')\n",
+    "        plt.imshow(dataset.read(1), cmap='viridis')\n",
     "        \n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "pip install rasterio==1.0a12 matplotlib"
    ]
   }
  ],
@@ -270,7 +209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Export.ipynb
+++ b/examples/Export.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exports\n",
+    "\n",
+    "This notebooks shows how we create an export from a project instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterfoundry.api import API\n",
+    "refresh_token = '<refresh_token>'\n",
+    "api = API(refresh_token=refresh_token, host='app.staging.rasterfoundry.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an export directly\n",
+    "\n",
+    "steps go here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get a bounding box for the export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8bcfe18fabd740459a3c8f0e4543ba8c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>Map</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "Map(center=[37.4398765951139, 283.35567345891246], controls=(DrawControl(layer=FeatureGroup(), polygon={'shapeOptions': {}}, polyline={'shapeOptions': {}}),), layers=(TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'), TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://tiles.staging.rasterfoundry.com/tiles/982520bf-16fe-42e8-9d5e-c786004fbbed/{z}/{x}/{y}/?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFUZEdSakZCTkVSQ1FqVkNRamxHUmpRMk0wSTFSRFZFTkRjME1EazVPVU01TkRRNU1qWXhOZyJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LXN0Zy5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMDQ5Mzg4OTE2NDUwMzk3NDAyNTEiLCJhdWQiOiJGU21UdmNFdzRReUdDOHA1QktIREN1Y2dJZldSS3VoRSIsImlhdCI6MTUyMDI4OTI0MiwiZXhwIjoxNTIwMzI1MjQyfQ.FmpD4BX3TGwrMPE4vnvDUIZzvvu07MIdQxXIgWx3RwktbThA5-XGpQowZj9bbjQiME_X-JGWDt2j8ova9ZOHmw1Sht0Qo8T4LKTo9N7AfVIqNFMr9_l39by3wuAEfuMA9C3zEu5FQanXtYBHSmqJxagVSohRJMx_9c6T6fjjJt5KnOB5JOphYGNN_Je1ZKszY7pdZbpP4Pq2pgJJJXOWoKMx5ThQf39UbxzKBWqG0CoFcOQ8SCe74KV-KQ6NCx_Sfk3uT8-scTlc-xfKcC9SgJxo3qOXC974vh-1eAR4Lfhg75TaKutJmUqrBrx8_uopR95ajn3TAIZHFozVmiXjqA')), layout=Layout(align_self=u'stretch', height=u'400px'), options=[u'keyboard_pan_offset', u'tap', u'attribution_control', u'max_zoom', u'min_zoom', u'bounce_at_zoom_limits', u'keyboard', u'scroll_wheel_zoom', u'dragging', u'inertia_max_speed', u'close_popup_on_click', u'zoom_control', u'box_zoom', u'double_click_zoom', u'tap_tolerance', u'zoom_start', u'keyboard_zoom_offset', u'inertia_deceleration', u'inertia', u'center', u'zoom', u'world_copy_jump', u'zoom_animation_threshold', u'touch_zoom'], scroll_wheel_zoom=True)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipyleaflet import DrawControl\n",
+    "\n",
+    "project = api.projects[-1]\n",
+    "m = project.get_map()\n",
+    "\n",
+    "dc = DrawControl()\n",
+    "m.add_control(dc)\n",
+    "project.add_to(m)\n",
+    "m\n",
+    "# Draw a polygon in the map below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def snap_to_360(x_coord):\n",
+    "    \"\"\"Snap an x coordinate to [-180, 180]\n",
+    "    \n",
+    "    Coordinates coming back from the API for some projects can be\n",
+    "    outside this range, and coordinates in the bbox outside this\n",
+    "    range make the export API upset. When it's upset, it returns\n",
+    "    an array with just a single 0 in it, which is not an accurate\n",
+    "    representation of the project normally.\n",
+    "    \"\"\"\n",
+    "    return x_coord - round((x_coord + 180) / 360, 0) * 360\n",
+    "\n",
+    "def geom_to_bbox(geom):\n",
+    "    coords = geom['geometry']['coordinates'][0]\n",
+    "    min_x = snap_to_360(min([point[0] for point in coords]))\n",
+    "    min_y = min([point[1] for point in coords])\n",
+    "    max_x = snap_to_360(max([point[0] for point in coords]))\n",
+    "    max_y = max([point[1] for point in coords])\n",
+    "    return ','.join(map(str, [min_x, min_y, max_x, max_y]))\n",
+    "\n",
+    "bbox = geom_to_bbox(dc.last_draw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create an export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_export = project.create_export(bbox=bbox, zoom=8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Export - 9ba49785-b909-49ac-818d-a5fafba4c938>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "project_export"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wait until the export is finished"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'EXPORTED'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "completed_export = project_export.wait_for_completion()\n",
+    "# will say 'EXPORTED' if the export is finished\n",
+    "completed_export.export_status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'8-4-6-9ba49785-b909-49ac-818d-a5fafba4c938.tiff'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f_names = api.client.Imagery.get_exports_uuid_files(uuid=project_export.id).result()\n",
+    "f_name = filter(lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(), f_names)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = api.client.Imagery.get_exports_uuid_files_filename(uuid=project_export.id, filename=f_name, token=api.api_token).result()\n",
+    "resp"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Export.ipynb
+++ b/examples/Export.ipynb
@@ -6,45 +6,43 @@
    "source": [
     "# Exports\n",
     "\n",
-    "This notebooks shows how we create an export from a project instance."
+    "This notebooks shows the steps on how we create an export using a project instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterfoundry.api import API\n",
+    "refresh_token = '<your_refresh_token>'\n",
+    "api = API(refresh_token=refresh_token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an export directly\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a polygon as the mask for the export"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "from rasterfoundry.api import API\n",
-    "refresh_token = '<refresh_token>'\n",
-    "api = API(refresh_token=refresh_token, host='app.staging.rasterfoundry.com')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create an export directly\n",
-    "\n",
-    "steps go here"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Get a bounding box for the export"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8bcfe18fabd740459a3c8f0e4543ba8c",
+       "model_id": "dedd95f0273e424bb7b442b2992bd7ba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -64,7 +62,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Map(center=[37.4398765951139, 283.35567345891246], controls=(DrawControl(layer=FeatureGroup(), polygon={'shapeOptions': {}}, polyline={'shapeOptions': {}}),), layers=(TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'), TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://tiles.staging.rasterfoundry.com/tiles/982520bf-16fe-42e8-9d5e-c786004fbbed/{z}/{x}/{y}/?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFUZEdSakZCTkVSQ1FqVkNRamxHUmpRMk0wSTFSRFZFTkRjME1EazVPVU01TkRRNU1qWXhOZyJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LXN0Zy5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMDQ5Mzg4OTE2NDUwMzk3NDAyNTEiLCJhdWQiOiJGU21UdmNFdzRReUdDOHA1QktIREN1Y2dJZldSS3VoRSIsImlhdCI6MTUyMDI4OTI0MiwiZXhwIjoxNTIwMzI1MjQyfQ.FmpD4BX3TGwrMPE4vnvDUIZzvvu07MIdQxXIgWx3RwktbThA5-XGpQowZj9bbjQiME_X-JGWDt2j8ova9ZOHmw1Sht0Qo8T4LKTo9N7AfVIqNFMr9_l39by3wuAEfuMA9C3zEu5FQanXtYBHSmqJxagVSohRJMx_9c6T6fjjJt5KnOB5JOphYGNN_Je1ZKszY7pdZbpP4Pq2pgJJJXOWoKMx5ThQf39UbxzKBWqG0CoFcOQ8SCe74KV-KQ6NCx_Sfk3uT8-scTlc-xfKcC9SgJxo3qOXC974vh-1eAR4Lfhg75TaKutJmUqrBrx8_uopR95ajn3TAIZHFozVmiXjqA')), layout=Layout(align_self=u'stretch', height=u'400px'), options=[u'keyboard_pan_offset', u'tap', u'attribution_control', u'max_zoom', u'min_zoom', u'bounce_at_zoom_limits', u'keyboard', u'scroll_wheel_zoom', u'dragging', u'inertia_max_speed', u'close_popup_on_click', u'zoom_control', u'box_zoom', u'double_click_zoom', u'tap_tolerance', u'zoom_start', u'keyboard_zoom_offset', u'inertia_deceleration', u'inertia', u'center', u'zoom', u'world_copy_jump', u'zoom_animation_threshold', u'touch_zoom'], scroll_wheel_zoom=True)"
+       "Map(center=[37.4398765951139, 283.35567345891246], controls=(DrawControl(layer=FeatureGroup(), polygon={'shapeOptions': {}}, polyline={'shapeOptions': {}}),), layers=(TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'), TileLayer(options=[u'opacity', u'attribution', u'max_zoom', u'detect_retina', u'min_zoom', u'tile_size'], url=u'https://tiles.staging.rasterfoundry.com/tiles/982520bf-16fe-42e8-9d5e-c786004fbbed/{z}/{x}/{y}/?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlFUZEdSakZCTkVSQ1FqVkNRamxHUmpRMk0wSTFSRFZFTkRjME1EazVPVU01TkRRNU1qWXhOZyJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LXN0Zy5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMDQ5Mzg4OTE2NDUwMzk3NDAyNTEiLCJhdWQiOiJGU21UdmNFdzRReUdDOHA1QktIREN1Y2dJZldSS3VoRSIsImlhdCI6MTUyMDM3MzQyMSwiZXhwIjoxNTIwNDA5NDIxfQ.eBmhxY4FfXu_Usmz8pF-aiGYrfH0vznGJB9SOObPTbKfc01CSwtrvWZdbnNsWHjlNmh3oOgwp-8FV_uUjOgl1NLFYaX429HKFo06O_11PORXgfLf4iu5As7ecFeVOaUOETIUZL0CqAHiBvGxwep0HH3Aef27HraweQl6opae5aSlHovMqoWEpNILpzg7GjEnFUOgIt0ooUUxmEcY-pauuZ0-17DPoJoBtnfx6vNEYtsX0Qen-Xo5zlzemuOaHdqozmc2c31PKQL-xcpg4YJK9Nihzpx4s0YlTXG3UD5pZYTKFSSbavhoBW_WJpM1LIOSWii-9-znJsJp1rzyhU6zJA')), layout=Layout(align_self=u'stretch', height=u'400px'), options=[u'keyboard_pan_offset', u'tap', u'attribution_control', u'max_zoom', u'min_zoom', u'bounce_at_zoom_limits', u'keyboard', u'scroll_wheel_zoom', u'dragging', u'inertia_max_speed', u'close_popup_on_click', u'zoom_control', u'box_zoom', u'double_click_zoom', u'tap_tolerance', u'zoom_start', u'keyboard_zoom_offset', u'inertia_deceleration', u'inertia', u'center', u'zoom', u'world_copy_jump', u'zoom_animation_threshold', u'touch_zoom'], scroll_wheel_zoom=True)"
       ]
      },
      "metadata": {},
@@ -81,12 +79,13 @@
     "m.add_control(dc)\n",
     "project.add_to(m)\n",
     "m\n",
+    "\n",
     "# Draw a polygon in the map below"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,36 +115,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create an export"
+    "### Create an export through a project instance"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "project_export = project.create_export(bbox=bbox, zoom=8)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Export - 9ba49785-b909-49ac-818d-a5fafba4c938>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "project_export"
    ]
   },
   {
@@ -157,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -166,46 +145,112 @@
        "u'EXPORTED'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "completed_export = project_export.wait_for_completion()\n",
-    "# will say 'EXPORTED' if the export is finished\n",
+    "# it will say 'EXPORTED' as the output of this block if the export is finished\n",
     "completed_export.export_status"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 24,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "u'8-4-6-9ba49785-b909-49ac-818d-a5fafba4c938.tiff'"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "f_names = api.client.Imagery.get_exports_uuid_files(uuid=project_export.id).result()\n",
-    "f_name = filter(lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(), f_names)[0]"
+    "### Download the export to memory"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp = api.client.Imagery.get_exports_uuid_files_filename(uuid=project_export.id, filename=f_name, token=api.api_token).result()\n",
-    "resp"
+    "import requests\n",
+    "\n",
+    "f_names = api.client.Imagery.get_exports_uuid_files(uuid=project_export.id).result()\n",
+    "f_name = filter(lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(), f_names)[0]\n",
+    "\n",
+    "url = 'https://app.staging.rasterfoundry.com/api/exports/{export_id}/files/{file_name}'.format(export_id=project_export.id, file_name=f_name)\n",
+    "params = {'token': api.api_token}\n",
+    "\n",
+    "export_resp = requests.get(url=url, params=params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot the expot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: numpy in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages\n",
+      "Requirement already satisfied: matplotlib in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages\n",
+      "Requirement already satisfied: rasterio==1.0a12 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages\n",
+      "Requirement already satisfied: subprocess32 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: backports.functools-lru-cache in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: cycler>=0.10 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: pytz in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: python-dateutil>=2.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: six>=1.10 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from matplotlib)\n",
+      "Requirement already satisfied: enum34 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
+      "Requirement already satisfied: cligj in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
+      "Requirement already satisfied: affine in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
+      "Requirement already satisfied: click-plugins in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
+      "Requirement already satisfied: attrs in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
+      "Requirement already satisfied: snuggs>=1.4.1 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from rasterio==1.0a12)\n",
+      "Requirement already satisfied: setuptools in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from kiwisolver>=1.0.1->matplotlib)\n",
+      "Requirement already satisfied: click>=4.0 in /Users/asu/Documents/work/azavea/raster-foundry-python-client/venv/lib/python2.7/site-packages (from cligj->rasterio==1.0a12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "pip install numpy matplotlib rasterio==1.0a12\n",
+    "# Install numpy matplotlib for plot to work"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARQAAAD8CAYAAAC2EFsiAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvFvnyVgAAElFJREFUeJzt3X+s1Xd9x/Hn69wfgG3lR8sIa6tFRRtcJlbW0miWTlOKbBk1MYZmWW8qCW5rE82WTZjJqtYluky7NdEqrp1oVMr8kd40dezamiz7o5RSEYGKXNs622BpvZTCinB/vPfH933xjF3g3Hs/955zD69HcnK/38/3e8/5fgi8ON/v+fFSRGBmVkKt2QdgZu3DgWJmxThQzKwYB4qZFeNAMbNiHChmVsy0B4qk1ZIOSOqXtHG6H9/Mpo6m830okjqAnwI3As8BO4FbImL/tB2EmU2Z6X6Gci3QHxFPR8QpYCuwdpqPwcymSOc0P97lwC/q1p8DrqvfQdIGYAPARRdd9I6r33L19B2d2QVo15O7XoqIhSXua7oD5bwiYjOwGWDFO1bEjh2PN/mIzNpbZ1fHz0vd13Sf8jwPXFm3fkWOmVkbmO5A2QkslbREUjewDuid5mMwsykyrac8ETEk6Q5gO9AB3B8R+6bzGMxs6kz7NZSIeBh4eLof18ymnt8pa2bFOFDMrBgHipkV40Axs2IcKGZWjAPFzIpxoJhZMQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysmEkFiqRnJf1Y0m5JT+TYAkl9kg7mz/k5Lkn3ZAXpHknXlJiAmbWOEs9Q/iAilkfEilzfCDwSEUuBR3Id4L3A0rxtAO4t8Nhm1kKm4pRnLbAll7cAN9eNfzUqjwHzJC2egsc3syaZbKAE8B+SdmWFKMCiiDiUy78EFuXyWDWkl0/y8c2shUy2RuNdEfG8pN8C+iT9pH5jRISkGM8d1ncbv+51r5vk4ZnZdJrUM5SIeD5/Hga+C1wLvDB6KpM/D+fuDdWQRsTmiFgRESsWXlakv9nMpsmEA0XSRZIuGV0GVgF7qapFe3K3HuDBXO4Fbs1Xe1YCR+tOjcysDUzmlGcR8F1Jo/fzjYj4d0k7gW2S1gM/Bz6Q+z8MrAH6gVeB2ybx2GbWgiYcKBHxNPC2McZ/BbxnjPEAbp/o45lZ6/M7Zc2sGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkV40Axs2IcKGZWjAPFzIpxoJhZMQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNizhsoku6XdFjS3rqxcfcXS+rJ/Q9K6hnrscxsZmvkGcpXgNVnjI2rv1jSAuBO4Dqq7p47R0PIzNrHeQMlIv4TGDhjeLz9xTcBfRExEBFHgD7+f0iZ2Qw30Wso4+0vbrjXWNIGSU9IeuLFl16c4OGZWTNM+qJs9u2Mq7/4PPfnKlKzGWqigTLe/uKGeo3NbGabaKCMt794O7BK0vy8GLsqx8ysjZy3ilTSN4EbgMskPUf1as2nGUd/cUQMSLoL2Jn7fTIizrzQa2YznKpLIK1pxTtWxI4djzf7MMzaWmdXx66IWFHivvxOWTMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkVc95PG5u1g+PHT/LfvzjK66+cy8GnB3jzGy9FghO/HmJwcJi5r53N8MgIXZ0dBCCge5b/eYyXn6HYBUHAlZe/lsHBYd7ypkt5aeBVajUxZ04n8+bNQTXR0eF/DpPlP0G7IAwNjVCriVmzOxkZCebPnc2JE4PECJw4MciRI1XAtO6XecwMDhS7IBw7forBwWGGBkcYGQm6ujvo7u5Egs4OMX/eHAYHhyG/H8jBMjEOFLsgzJs7i46OGp1dNSKC4eERRkZGADh1ahhJdHZ2MBKBmnysM5kDxS4ItVqNWk0MDY7Q0Vmjo1ZjeDhQTRw7forRby6sqYqTkeGRZh7ujDXRKtKPS3pe0u68ranbtimrSA9IuqlufHWO9UvaeObjmE0l1aCzs1aFx0gwMhLUauLkr4dYeNlFnP4mVFXXUWo1P0+ZiIlWkQLcHRHL8/YwgKRlwDrgrfk7X5DUIakD+DxVVeky4Jbc12xavPLKSUYiePGl/2F4OPj1ySGGh0eYPbuTU6eGQDB4auj0/sPDvooyEROtIj2btcDWiDgZEc9Qffv9tXnrj4inI+IUsDX3NZsWXV0djIwEr79yLlC9jDx7Theqide8pptjx05WO+ZTFfkJyoRM5hrKHZL25CnRaPG5q0itJc3q7oCAWbM76eis0dlZ48Srgxw7dpIXXjzOqycG6er+zRvZan5PyoRM9K2A9wJ3Ub26dhfwWeCDJQ4oIjYDm6Gq0Shxn2YXXTzrrNsuncbjaHcTCpSIeGF0WdKXgYdy9VyVo64iNWtzE3peN9prnN4HjL4C1AuskzRL0hJgKfA4VWPgUklLJHVTXbjtnfhhm1krmmgV6Q2SllOd8jwLfAggIvZJ2gbsB4aA2yNiOO/nDqo+4w7g/ojYV3w2ZtZUriI1u8C5itTMWpIDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkV40Axs2IcKGZWjAPFzIpppIr0Skk/kLRf0j5JH87xBZL6JB3Mn/NzXJLuycrRPZKuqbuvntz/oKSeqZuWmTVDI89QhoC/iohlwErg9qwR3Qg8EhFLgUdyHaq60aV520DV4YOkBVRfcH0dVZPgnXUFYWbWBhqpIj0UEU/m8jHgKarWv7XAltxtC3BzLq8FvhqVx4B5WbtxE9AXEQMRcQToY+zOZDObocZ1DUXSVcDbgR3Aoog4lJt+CSzK5UnVkbqK1GzmajhQJF0MfBv4SES8Ur8tqi6OIn0cEbE5IlZExIqFly0scZdmNk0aChRJXVRh8vWI+E4OvzDaIJg/D+f42epIz1VTamZtoJFXeQTcBzwVEZ+r29QLjL5S0wM8WDd+a77asxI4mqdG24FVkubnxdhVOWZmbaKRsvR3An8K/FjS7hz7W+DTwDZJ64GfAx/IbQ8Da4B+4FXgNoCIGJB0F1XPMcAnI2KgyCzMrCW4itTsAucqUjNrSQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK2YyVaQfl/S8pN15W1P3O5uyivSApJvqxlfnWL+kjWM9npnNXI18SfVoFemTki4Bdknqy213R8Q/1u+cNaXrgLcCvw18X9Kbc/PngRupSr52SuqNiP0lJmJmzXfeQMkKjEO5fEzSaBXp2awFtkbESeAZSf1UXcYA/RHxNICkrbmvA8WsTUymihTgDkl7JN1fV3zuKlKzC9RkqkjvBd4ILKd6BvPZEgfkKlKzmauRayhjVpFGxAt1278MPJSr56ocdRWpWRubcBXpaK9xeh+wN5d7gXWSZklaAiwFHqdqDFwqaYmkbqoLt71lpmFmrWAyVaS3SFoOBPAs8CGAiNgnaRvVxdYh4PaIGAaQdAdVn3EHcH9E7Cs4FzNrMleRml3gXEVqZi3JgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFNPIl1bMlPS7pR1lF+okcXyJpR9aKPpBfPE1+OfUDOb4ju3xG72vMilIzaw+NPEM5Cbw7It5G1cGzWtJK4DNUVaRvAo4A63P/9cCRHL879zuzonQ18AVJHSUnY2bNdd5AicrxXO3KWwDvBr6V41uAm3N5ba6T29+TVRynK0oj4hmgvqLUzNpAQ9dQJHVkhcZhoA/4GfByRAzlLvW1oqcrR3P7UeBSXEVq1vYaCpSIGI6I5VRtf9cCV0/VAbmK1GzmGterPBHxMvAD4HpgnqTRorD6WtHTVaS5fS7wK85dUWpmbaCRV3kWSpqXy3OAG4GnqILl/blbD/BgLvfmOrn90ajaxM5WUWpmbaKRKtLFwJZ8RaYGbIuIhyTtB7ZK+hTwQ6r+Y/Ln1yT1AwNUr+ycs6LUzNqDq0jNLnCuIjWzluRAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlaMA8XMinGgmFkxDhQzK8aBYmbFOFDMrBgHipkV40Axs2ImU0X6FUnPSNqdt+U5Lkn3ZOXoHknX1N1Xj6SDees522Oa2czUyJdUj1aRHpfUBfyXpO/ltr+OiG+dsf97qb7RfilwHXAvcJ2kBcCdwAqq5sFdknoj4kiJiZhZ802mivRs1gJfzd97jKq/ZzFwE9AXEQMZIn1UHcdm1iYmVEUaETty09/nac3dkmbl2NkqRxuqIjWzmWtCVaSSfgfYRFVJ+nvAAuCjJQ7I3cZmM9dEq0hXR8ShPK05CfwrVecxnL1ytKEqUncbm81cE60i/UleF0GSgJuBvfkrvcCt+WrPSuBoRBwCtgOrJM2XNB9YlWNm1iYmU0X6qKSFgIDdwJ/l/g8Da4B+4FXgNoCIGJB0F7Az9/tkRAyUm4qZNZurSM0ucK4iNbOW5EAxs2IcKGZWjAPFzIpxoJhZMQ4UMyvGgWJmxThQzKwYB4qZFeNAMbNiHChmVowDxcyKcaCYWTEOFDMrxoFiZsU4UMysGAeKmRXjQDGzYhwoZlZMw4GSZV8/lPRQri+RtCM7jB+Q1J3js3K9P7dfVXcfm3L8gKSbSk/GzJprPM9QPgw8Vbf+GeDuiHgTcARYn+PrgSM5fnfuh6RlwDrgrVQVpF/Ib9I3szbRaBXpFcAfAv+S6wLeDYwWpW+h6uaBqtt4Sy5/C3hP7r8W2BoRJyPiGaqajdFyMDNrA4308gD8E/A3wCW5finwckQM5Xp9T/HpDuOIGJJ0NPe/HHis7j7H7DaWtAHYkKsnO7s69p65T5u4DHip2QcxBdp1XtC+c3tLqTs6b6BI+iPgcETsknRDqQc+m4jYDGzOx36iVF9Iq2nXubXrvKB95ybpiVL31cgzlHcCfyxpDTAbeC3wz8A8SZ35LKW+p3i0w/g5SZ3AXOBXNNhtbGYz13mvoUTEpoi4IiKuorqo+mhE/AlVafr7c7ce4MFc7s11cvujUdUT9gLr8lWgJcBSwLWAZm2k0WsoY/kosFXSp4AfAvfl+H3A1yT1AwNUIURE7JO0DdgPDAG3R8TweR5j8ySOr9W169zadV7QvnMrNq+W7jY2s5nF75Q1s2IcKGZWTMsGiqTV+Rb9fkkbm3085yPpfkmHJe2tG1sgqU/Swfw5P8cl6Z6c2x5J19T9Tk/uf1BSz1iPNZ0kXSnpB5L2S9on6cM53g5zmy3pcUk/yrl9Isfb4mMlTfm4TES03A3oAH4GvAHoBn4ELGv2cZ3nmH8fuAbYWzf2D8DGXN4IfCaX1wDfAwSsBHbk+ALg6fw5P5fnN3lei4FrcvkS4KfAsjaZm4CLc7kL2JHHvA1Yl+NfBP48l/8C+GIurwMeyOVl+Xd0FrAk/+52tMDfyb8EvgE8lOtTPq+mTvgcfxDXA9vr1jcBm5p9XA0c91VnBMoBYHEuLwYO5PKXgFvO3A+4BfhS3fj/2a8VblRvD7ix3eYGvAZ4EriO6t2wnWf+XQS2A9fncmfupzP/ftbv18T5XAE8QvURmYfyOKd8Xq16ynP67ftpzLfpzwCLIuJQLv8SWJTLZ5tfS887nwq/nep/8raYW54W7AYOA31U/ws39LESoP5jJa02t9GPy4zkesMfl2ES82rVQGk7UUX8jH2NXtLFwLeBj0TEK/XbZvLcImI4IpZT/Y9+LXB1kw9p0uo/LjPdj92qgdIub9N/QdJigPx5OMfPNr+WnLekLqow+XpEfCeH22JuoyLiZap3f19PfqwkN431sRJa/GMlox+XeRbYSnXac/rjMrnPlMyrVQNlJ7A0r0p3U10o6m3yMU1E/ccQzvx4wq35ishK4GiePmwHVkman6+arMqxpsmvnrgPeCoiPle3qR3mtlDSvFyeQ3Vt6Clm+MdKopkfl2n2xbBzXFRaQ/WKws+AjzX7eBo43m8Ch4BBqnPN9VTnoY8AB4HvAwtyXwGfz7n9GFhRdz8fpPqumH7gthaY17uoTmf2ALvztqZN5va7VB8b2QPsBf4ux9+Q/3D6gX8DZuX47Fzvz+1vqLuvj+WcDwDvbfbc6o7rBn7zKs+Uz8tvvTezYlr1lMfMZiAHipkV40Axs2IcKGZWjAPFzIpxoJhZMQ4UMyvmfwGjtnOG2iAVcQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from rasterio.io import MemoryFile\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "data = export_resp.content\n",
+    "\n",
+    "with MemoryFile(data) as memfile:\n",
+    "    with memfile.open() as dataset:\n",
+    "        plt.imshow(dataset.read(1), cmap='Purples')\n",
+    "        \n",
+    "plt.show()"
    ]
   }
  ],

--- a/examples/Export.ipynb
+++ b/examples/Export.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "from ipyleaflet import DrawControl\n",
     "\n",
-    "project = api.projects[4]\n",
+    "project = api.projects[-1]\n",
     "m = project.get_map()\n",
     "\n",
     "dc = DrawControl()\n",
@@ -87,7 +87,7 @@
     "    max_y = max([point[1] for point in coords])\n",
     "    return ','.join(map(str, [min_x, min_y, max_x, max_y]))\n",
     "\n",
-    "bbox = geom_to_bbox(dc.last_draw)"
+    "bbox = geom_to_bbox(dc.last_draw)\n"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project_export = project.create_export(bbox=bbox, zoom=8)"
+    "project_export = project.create_export(bbox=bbox, zoom=8, raster_size=1000)"
    ]
   },
   {
@@ -122,6 +122,16 @@
     "completed_export = project_export.wait_for_completion()\n",
     "# it will say 'EXPORTED' as the output of this block if the export is finished\n",
     "completed_export.export_status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the export is done, we will get a list of download URLs\n",
+    "project_export.files"
    ]
   },
   {
@@ -191,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -203,7 +203,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "pip install numpy matplotlib rasterio==1.0a8"
+    "pip install numpy matplotlib rasterio==1.0a12"
    ]
   }
  ],

--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -231,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -147,9 +147,9 @@
     "import matplotlib.pyplot as plt\n",
     "project = api.projects[3]\n",
     "bbox = '-121.726057,37.278423,-121.231672,37.377250'\n",
-    "data = project.geotiff(bbox, zoom=17)\n",
+    "thumbnail = project.geotiff(bbox, zoom=10)\n",
     "\n",
-    "with MemoryFile(data) as memfile:\n",
+    "with MemoryFile(thumbnail) as memfile:\n",
     "    with memfile.open() as dataset:\n",
     "        plt.imshow(dataset.read(1), cmap='RdBu')\n",
     "        \n",
@@ -183,7 +183,9 @@
     "### Asynchronous export\n",
     "\n",
     "Asynchronous export is good when you have a large project, or when you need a high\n",
-    "zoom level in the resulting geotiff."
+    "zoom level in the resulting geotiff. Creating an asynchronous export requires only a\n",
+    "bbox and zoom level for this project. Created exports run remotely. For examples of what\n",
+    "you can do with exports, check out the [Exports](./Export.ipynb) notebook."
    ]
   },
   {
@@ -192,9 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the asynchronous export\n",
-    "\n",
-    "# Visualize it somehow"
+    "export = project.create_export(bbox, zoom=10)"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -50,9 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Change the index in projects[3] to a value within your list of projects\n",
@@ -74,9 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Change the index in projects[4] to a value within your list of projects\n",
@@ -90,21 +86,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Project export"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Export as PNG"
+    "## Project export\n",
+    "\n",
+    "### Synchronous export with the tile server\n",
+    "\n",
+    "Synchronous export is good when your project doesn't cover a large\n",
+    "area, or when you don't need a high zoom level in the resulting\n",
+    "geotiff.\n",
+    "\n",
+    "#### Export as PNG"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -118,9 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Image(project.png(bbox, zoom=15))"
@@ -130,14 +124,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Export as GeoTIFF"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Display in the notebook\n",
+    "#### Export as GeoTIFF\n",
+    "\n",
+    "#### Display in the notebook\n",
     "\n",
     "Note: this example requires\n",
     "[`numpy`](http://www.numpy.org/),\n",
@@ -171,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Save as a file"
+    "#### Save as a file"
    ]
   },
   {
@@ -191,15 +180,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Asynchronous export\n",
+    "\n",
+    "Asynchronous export is good when you have a large project, or when you need a high\n",
+    "zoom level in the resulting geotiff."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the asynchronous export\n",
+    "\n",
+    "# Visualize it somehow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Installs"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",

--- a/examples/Uploads.ipynb
+++ b/examples/Uploads.ipynb
@@ -151,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -7,7 +7,7 @@ from bravado.client import SwaggerClient
 from bravado.swagger_model import load_file
 from simplejson import JSONDecodeError
 
-from .models import Project, MapToken, Analysis
+from .models import Project, MapToken, Analysis, Export
 from .exceptions import RefreshTokenException
 from .aws.s3 import str_to_file
 from .settings import RV_TEMP_URI
@@ -135,6 +135,24 @@ class API(object):
             for analysis in paginated_analyses.results:
                 analyses.append(Analysis(analysis, self))
         return analyses
+
+    @property
+    def exports(self):
+        """List exports a user has access to
+
+        Returns:
+            List[Export]
+        """
+        has_next = True
+        page = 0
+        exports = []
+        while has_next:
+            paginated_exports = self.client.Imagery.get_exports(page=page).result()
+            has_next = paginated_exports.hasNext
+            page = paginated_exports.page + 1
+            for export in paginated_exports.results:
+                exports.append(Export(export, self))
+        return exports
 
     def get_datasources(self, **kwargs):
         return self.client.Datasources.get_datasources(**kwargs).result()

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -36,6 +36,7 @@ class API(object):
 
         spec = load_file(SPEC_PATH)
 
+        self.app_host = host
         spec['host'] = host
         spec['schemes'] = [scheme]
 

--- a/rasterfoundry/models/__init__.py
+++ b/rasterfoundry/models/__init__.py
@@ -2,3 +2,4 @@ from .project import Project # NOQA
 from .map_token import MapToken # NOQA
 from .upload import Upload # NOQA
 from .analysis import Analysis # NOQA
+from .export import Export # NOQA

--- a/rasterfoundry/models/analysis.py
+++ b/rasterfoundry/models/analysis.py
@@ -1,6 +1,5 @@
 """An Analysis is a set of operations which take projects as inputs and output raster imagery"""
 import requests
-from shapely.geometry import box, mapping
 
 from .. import NOTEBOOK_SUPPORT
 from .export import Export

--- a/rasterfoundry/models/analysis.py
+++ b/rasterfoundry/models/analysis.py
@@ -37,10 +37,7 @@ class Analysis(object):
         self.name = analysis.name
         self.id = analysis.id
 
-    def _get_async_export(self, bbox, zoom, **opts):
-        return Export.create_export(self.api, bbox=bbox, zoom=zoom, analysis=self, **opts)
-
-    def _get_sync_export(self, bbox, zoom):
+    def get_thumbnail(self, bbox, zoom, raw=False):
         export_path = self.EXPORT_TEMPLATE.format(analysis=self.id)
         request_path = '{scheme}://{host}{export_path}'.format(
             scheme=self.api.scheme, host=self.api.tile_host, export_path=export_path
@@ -52,6 +49,7 @@ class Analysis(object):
                 'bbox': bbox,
                 'zoom': zoom,
                 'token': self.api.api_token,
+                'colorCorrect': 'false' if raw else 'true'
             }
         )
         if response.status_code == requests.codes.gateway_timeout:
@@ -62,22 +60,18 @@ class Analysis(object):
         response.raise_for_status()
         return response
 
-    def get_export(self, bbox, async=False, zoom=10, **exportOpts):
+    def create_export(self, bbox, zoom=10, **exportOpts):
         """Download this Analysis as a single band tiff
 
         Args:
             bbox (str): Bounding box(formatted as 'x1,y1,x2,y2') for the download
-            async (bool): Whether to create an asynchronous export job
             zoom (int): Zoom level for the download
             exportOpts (dict): Additional parameters to pass to an async export job
 
         Returns:
             Export
         """
-        if not async:
-            return self._get_sync_export(bbox, zoom)
-        else:
-            return self._get_async_export(bbox, zoom, **exportOpts)
+        return Export.create_export(self.api, bbox=bbox, zoom=zoom, analysis=self, **exportOpts)
 
     def tms(self, node=None):
         """Returns a TMS URL for this project

--- a/rasterfoundry/models/export.py
+++ b/rasterfoundry/models/export.py
@@ -74,7 +74,8 @@ class Export(object):
                       analysis=None,
                       visibility='PRIVATE',
                       source=None,
-                      export_type='S3'):
+                      export_type='S3',
+                      raster_size=4000):
         """Create an asynchronous export job for a project or analysis
 
         Only one of project_id or analysis_id should be specified
@@ -87,10 +88,11 @@ class Export(object):
             analysis (Analysis): the analysis to export
             visibility (Visibility): what the export's visibility should be set to
             source (str): the destination for the exported files
-            exportType (str): one of 'S3', 'LOCAL', or 'DROPBOX'
+            export_type (str): one of 'S3', 'LOCAL', or 'DROPBOX'
+            raster_size (int): desired tiff size after export, 4000 by default - same as backend
 
         Returns:
-            ???
+            An export object
         """
 
         if project is not None and analysis is not None:
@@ -117,7 +119,8 @@ class Export(object):
         export_create = {
             'exportOptions': {
                 'mask': mapping(box_poly),
-                'resolution': zoom
+                'resolution': zoom,
+                'rasterSize': raster_size
             },
             'projectId': None,
             'exportStatus': 'TOBEEXPORTED',
@@ -141,6 +144,9 @@ class Export(object):
 
     def download_file_bytes(self):
         """Download the exported file from this export to memory
+
+        Returns:
+            a binary file
         """
         fnames = self.api.client.Imagery.get_exports_uuid_files(uuid=self.id).result()
         fname = filter(lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(), fnames)[0]

--- a/rasterfoundry/models/export.py
+++ b/rasterfoundry/models/export.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel('INFO')
 
+
 class Export(object):
     def __repr__(self):
         return '<Export - {}>'.format(self.name)

--- a/rasterfoundry/models/export.py
+++ b/rasterfoundry/models/export.py
@@ -36,9 +36,14 @@ class Export(object):
     def files(self):
         try:
             fnames_res = self.api.client.Imagery.get_exports_uuid_files(uuid=self.id).result()
-            fnames = filter(lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(), fnames_res)
-            return ['https://{app_host}/api/exports/{export_id}/files/{file_name}'.format(
-                app_host=self.api.app_host, export_id=self.id, file_name=fname) for fname in fnames]
+            fnames = filter(
+                lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(),
+                fnames_res)
+            return [
+                'https://{app_host}/api/exports/{export_id}/files/{file_name}'.format(
+                    app_host=self.api.app_host,
+                    export_id=self.id,
+                    file_name=fname) for fname in fnames]
         except exception.HTTPNotFound:
             logger.info("The files can't be found until an export is completed")
 

--- a/rasterfoundry/models/export.py
+++ b/rasterfoundry/models/export.py
@@ -1,0 +1,87 @@
+"""An Export is a job to get underlying geospatial data out of Raster Foundry"""
+
+from shapely.geometry import mapping, box, MultiPolygon
+
+
+class Export(object):
+    def __repr__(self):
+        return '<Export - {}>'.format(self.name)
+
+    def __init__(self, export, api):
+        """Instantiate a new Export
+
+        Args:
+            export (Export): generated Export object from specification
+            api (API): api used to make requests on behalf of the export
+        """
+
+        self._export = export
+        # Someday, exports will have names, but not yet
+        self.name = export.id
+        self.id = export.id
+        self.api = api
+
+    @classmethod
+    def create_export(cls,
+                      api,
+                      bbox,
+                      zoom,
+                      project=None,
+                      analysis=None,
+                      visibility='PRIVATE',
+                      source=None,
+                      export_type='LOCAL'):
+        """Create an asynchronous export job for a project or analysis
+
+        Only one of project_id or analysis_id should be specified
+
+        Args:
+            api (API): API to use for requests
+            bbox (str): comma-separated bounding box of region to export
+            zoom (int): the zoom level for performing the export
+            project (Project): the project to export
+            analysis (Analysis): the analysis to export
+            visibility (Visibility): what the export's visibility should be set to
+            source (str): the destination for the exported files
+            exportType (str): one of 'S3', 'LOCAL', or 'DROPBOX'
+
+        Returns:
+            ???
+        """
+
+        if project is not None and analysis is not None:
+            raise ValueError(
+                'Ambiguous export target -- only one of project or analysis should '
+                'be specified')
+        elif project is None and analysis is None:
+            raise ValueError(
+                'Nothing to export -- one of project or analysis must be specified'
+            )
+        elif project is not None:
+            update_dict = {
+                'projectId': project.id,
+                'organizationId': project._project.organizationId
+            }
+        else:
+            update_dict = {
+                'toolRunId': analysis.id,
+                'organizationId': analysis._analysis.organizationId
+            }
+
+        box_poly = MultiPolygon([box(*map(float, bbox.split(',')))])
+
+        export_create = {
+            'exportOptions': {
+                'mask': mapping(box_poly),
+                'resolution': zoom
+            },
+            'projectId': None,
+            'exportStatus': 'TOBEEXPORTED',
+            'exportType': export_type,
+            'source': source,
+            'visibility': visibility,
+            'toolRunId': None,
+            'organizationId': None
+        }
+        export_create.update(update_dict)
+        return api.client.Imagery.post_exports(Export=export_create).result()

--- a/rasterfoundry/models/export.py
+++ b/rasterfoundry/models/export.py
@@ -26,13 +26,14 @@ class Export(object):
         self.name = export.id
         self.id = export.id
         self.api = api
-        self.exportStatus = export.exportStatus
+        self.export_status = export.exportStatus
+        self.path = export.exportOptions.source
 
     @classmethod
     def poll_export_status(cls,
                            api,
                            export_id,
-                           until=['COMPLETE', 'FAILED'],
+                           until=['EXPORTED', 'FAILED'],
                            delay=15):
         """Poll the status of an export until it is done
 
@@ -70,7 +71,7 @@ class Export(object):
                       analysis=None,
                       visibility='PRIVATE',
                       source=None,
-                      export_type='LOCAL'):
+                      export_type='S3'):
         """Create an asynchronous export job for a project or analysis
 
         Only one of project_id or analysis_id should be specified
@@ -124,7 +125,10 @@ class Export(object):
             'organizationId': None
         }
         export_create.update(update_dict)
-        return api.client.Imagery.post_exports(Export=export_create).result()
+        return Export(
+            api.client.Imagery.post_exports(Export=export_create).result(),
+            api
+        )
 
     def wait_for_completion(self):
         """Wait until this export succeeds or fails, returning the completed export

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -123,17 +123,19 @@ class Project(object):
         response.raise_for_status()
         return response
 
-    def create_export(self, bbox, zoom=10):
+    def create_export(self, bbox, zoom=10, raster_size=4000):
         """Create an export job for this project
 
         Args:
             bbox (str): Bounding box (formatted as 'x1,y1,x2,y2') for the download
             zoom (int): Zoom level for the download
+            raster_size (int): desired tiff size after export, 4000 by default - same as backend
 
         Returns:
             Export
         """
-        return Export.create_export(self.api, bbox=bbox, zoom=zoom, project=self)
+        return Export.create_export(
+            self.api, bbox=bbox, zoom=zoom, project=self, raster_size=raster_size)
 
     def geotiff(self, bbox, zoom=10, raw=False):
         """Download this project as a geotiff

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -139,7 +139,7 @@ class Project(object):
             raw (bool): whether to do a raw export without color correction
 
         Returns:
-            str
+            HttpResponse or Export
         """
         if not async:
             return self._get_sync_export(bbox, zoom, export_format, raw)

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -92,7 +92,7 @@ class Project(object):
         if resp.results:
             return MapToken(resp.results[0], self.api)
 
-    def _get_sync_export(self, bbox, zoom, export_format, raw):
+    def get_thumbnail(self, bbox, zoom, export_format, raw):
         headers = self.api.http.session.headers.copy()
         headers['Accept'] = 'image/{}'.format(
             export_format
@@ -123,28 +123,17 @@ class Project(object):
         response.raise_for_status()
         return response
 
-    def _get_async_export(self, bbox, zoom):
-        return Export.create_export(self.api, bbox=bbox, zoom=zoom, project=self)
-
-    def get_export(self, bbox, zoom=10, async=False, export_format='png', raw=False):
-        """Download this project as a file
-
-        PNGs will be returned if the export_format is anything other than tiff
+    def create_export(self, bbox, zoom=10):
+        """Create an export job for this project
 
         Args:
             bbox (str): Bounding box (formatted as 'x1,y1,x2,y2') for the download
             zoom (int): Zoom level for the download
-            async (bool): Whether to create an asynchronous export job
-            export_format (str): Requested download format
-            raw (bool): whether to do a raw export without color correction
 
         Returns:
-            HttpResponse or Export
+            Export
         """
-        if not async:
-            return self._get_sync_export(bbox, zoom, export_format, raw)
-        else:
-            return self._get_async_export(bbox, zoom)
+        return Export.create_export(self.api, bbox=bbox, zoom=zoom, project=self)
 
     def geotiff(self, bbox, zoom=10, raw=False):
         """Download this project as a geotiff
@@ -159,7 +148,7 @@ class Project(object):
             str
         """
 
-        return self.get_export(bbox, zoom, 'tiff', raw).content
+        return self.get_thumbnail(bbox, zoom, 'tiff', raw).content
 
     def png(self, bbox, zoom=10, raw=False):
         """Download this project as a png
@@ -174,7 +163,7 @@ class Project(object):
             str
         """
 
-        return self.get_export(bbox, zoom, 'png', raw).content
+        return self.get_thumbnail(bbox, zoom, 'png', raw).content
 
     def tms(self):
         """Return a TMS URL for a project"""

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -3701,7 +3701,7 @@ definitions:
         type: integer
         description: epsg projection code
       mask:
-        type: string
+        type: object
         description: GeoJSON multipolygon
       stitch:
         type: boolean

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -2371,14 +2371,11 @@ parameters:
     type: string
     required: false
     enum:
-      - CREATED
+      - NOTEXPORTED
+      - TOBEEXPORTED
       - EXPORTING
       - EXPORTED
-      - QUEUED
-      - PROCESSING
-      - COMPLETE
       - FAILED
-      - ABORTED
   source:
     name: source
     description: Feed source URI
@@ -3642,23 +3639,15 @@ definitions:
         projectId:
           type: string
           format: uuid
-        sceneIds:
-          type: array
-          items:
-            type: string
-            format: uuid
         exportStatus:
           type: string
           description: Status of export
           enum:
-            - CREATED
+            - NOTEXPORTED
+            - TOBEEXPORTED
             - EXPORTING
             - EXPORTED
-            - QUEUED
-            - PROCESSING
-            - COMPLETE
             - FAILED
-            - ABORTED
         exportType:
           type: string
           description: Source of exports
@@ -3684,20 +3673,6 @@ definitions:
     - $ref: '#/definitions/BaseModel'
     - $ref: '#/definitions/UserTrackingMixin'
     - $ref: '#/definitions/ExportCreate'
-    - type: object
-      properties:
-        exportStatus:
-          type: string
-          description: Status of export
-          enum:
-            - CREATED
-            - EXPORTING
-            - EXPORTED
-            - QUEUED
-            - PROCESSING
-            - COMPLETE
-            - FAILED
-            - ABORTED
   ExportPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -3726,7 +3701,7 @@ definitions:
         type: integer
         description: epsg projection code
       mask:
-        type: object
+        type: string
         description: GeoJSON multipolygon
       stitch:
         type: boolean

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -1896,7 +1896,8 @@ paths:
         200:
           description: The content of the reqested file
           schema:
-            type: file
+            type: string
+            format: binary
         404:
           description: |
             UUID does not reference an export that exists, the user has access to, and has finished successfully. The filename may not exist

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -1887,6 +1887,11 @@ paths:
           in: path
           type: string
           description: The filename of the file the user wishes to download. Filenames of an export need to first be fetched.
+        - name: token
+          required: true
+          in: query
+          type: string
+          description: API token
       responses:
         200:
           description: The content of the reqested file
@@ -3700,9 +3705,6 @@ definitions:
       crs:
         type: integer
         description: epsg projection code
-      mask:
-        type: object
-        description: GeoJSON multipolygon
       stitch:
         type: boolean
         description: stitch tiles into a single geotiff if possible

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setuptools.setup(
         'requests >= 2.9.1',
         'bravado >= 8.4.0',
         'boto3 >= 1.4.4',
-        'future >= 0.16.0'
+        'future >= 0.16.0',
+        'shapely >= 1.6.4post1'
     ],
     extras_require={
         'notebook': [


### PR DESCRIPTION
Overview
-----

This PR adds support for asynchronous exports to analyses and projects. It includes:

- an `Export` model to provide sugar around the bravado auto-generated API client
- new or updated example notebooks for analyses and projects to show asynchronous exports
- an example notebook for exports to show users everything they can do with `Export` objects
- a change from `get_export` to `get_thumbnail` for synchronous exports
- a `create_export` method for projects and analyses

Testing
-----

- run through the `Export`, `Project`, and `Analysis` example notebooks with an api pointed at
  staging

Supersedes #47 

Closes #47 

Closes #46 

Closes #45