### PR TITLE
Point to permanent location by default for spec

### DIFF
--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -21,7 +21,7 @@ except ImportError:
 
 SPEC_PATH = os.getenv(
     'RF_API_SPEC_PATH',
-    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/master/spec.yml'
+    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/1.4.0/spec/spec.yml'
 )
 
 


### PR DESCRIPTION
Overview
-----

This PR points to a specific release of the API spec by default, instead of whatever happens to be on
`master`.

It also removes the locally stored spec to avoid confusing people (and for fun!).

Testing
-----

- ci
- initialize a client --

```python
>>> from rasterfoundry.api import API
>>> client = API(api_token='your api token here')
>>> #or
>>> client = API('your refresh token here')
```

- if it succeeds, you're good

Closes #57 