### PR TITLE
Add convenience functions and example notebook for datasource CRUD

### DIFF
--- a/examples/Datasources.ipynb
+++ b/examples/Datasources.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Datasources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('/Users/xunzesu/Documents/work/azavea/raster-foundry-python-client/rasterfoundry')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterfoundry.api import API\n",
+    "from rasterfoundry.models.datasource import Datasource\n",
+    "refresh_token = \"<refresh_token>\"\n",
+    "api = API(refresh_token=refresh_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api.get_datasources()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "band_one = api.create_datasource_band('red', 0, '')\n",
+    "band_two = api.create_datasource_band('green', 1, '')\n",
+    "band_three = api.create_datasource_band('blue', 2, '')\n",
+    "bands = [band_one, band_two, band_three]\n",
+    "bands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = Datasource.create(api, 'Test Datasource', bands)\n",
+    "result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Datasources.ipynb
+++ b/examples/Datasources.ipynb
@@ -13,16 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.append('/path/to/raster-foundry-python-client')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from rasterfoundry.api import API\n",
     "from rasterfoundry.models.datasource import Datasource\n",
     "refresh_token = '<refresh_token>'\n",

--- a/examples/Datasources.ipynb
+++ b/examples/Datasources.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append('/Users/xunzesu/Documents/work/azavea/raster-foundry-python-client/rasterfoundry')"
+    "sys.path.append('/Users/asu/Documents/work/azavea/raster-foundry-python-client')"
    ]
   },
   {
@@ -25,8 +25,8 @@
    "source": [
     "from rasterfoundry.api import API\n",
     "from rasterfoundry.models.datasource import Datasource\n",
-    "refresh_token = \"<refresh_token>\"\n",
-    "api = API(refresh_token=refresh_token)"
+    "refresh_token = '2oECtdfzvjjbmao4iNtCyLhrYeMb6Y_r3gQIAkMiSDkbg'\n",
+    "api = API(refresh_token=refresh_token, host='localhost:9091', scheme='http')"
    ]
   },
   {
@@ -44,11 +44,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "band_one = api.create_datasource_band('red', 0, '')\n",
-    "band_two = api.create_datasource_band('green', 1, '')\n",
-    "band_three = api.create_datasource_band('blue', 2, '')\n",
-    "bands = [band_one, band_two, band_three]\n",
-    "bands"
+    "band_one = Datasource.create_datasource_band('red', '0', 100.0)\n",
+    "band_two = Datasource.create_datasource_band('green', '1', 200.0)\n",
+    "band_three = Datasource.create_datasource_band('blue', '2', 300.0)\n",
+    "result = Datasource.create(api, 'Test Datasource 5', [band_one, band_two, band_three])"
    ]
   },
   {
@@ -57,9 +56,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = Datasource.create(api, 'Test Datasource', bands)\n",
-    "result"
+    "datasource = api.get_datasource_by_id(result.id)\n",
+    "datasource.name = datasource.name + ' updated'\n",
+    "datasource_dict = vars(datasource)['_Model__dict']\n",
+    "datasource_dict['createdAt'] = datasource.createdAt.isoformat()\n",
+    "datasource_dict['modifiedAt'] = datasource.modifiedAt.isoformat()\n",
+    "datasource_dict\n",
+    "Datasource.update(api, datasource.id, datasource_dict)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -71,14 +82,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/examples/Datasources.ipynb
+++ b/examples/Datasources.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append('/Users/asu/Documents/work/azavea/raster-foundry-python-client')"
+    "sys.path.append('/path/to/raster-foundry-python-client')"
    ]
   },
   {
@@ -25,8 +25,15 @@
    "source": [
     "from rasterfoundry.api import API\n",
     "from rasterfoundry.models.datasource import Datasource\n",
-    "refresh_token = '2oECtdfzvjjbmao4iNtCyLhrYeMb6Y_r3gQIAkMiSDkbg'\n",
-    "api = API(refresh_token=refresh_token, host='localhost:9091', scheme='http')"
+    "refresh_token = '<refresh_token>'\n",
+    "api = API(refresh_token=refresh_token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List datasources"
    ]
   },
   {
@@ -39,6 +46,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create datasource bands"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -47,7 +61,14 @@
     "band_one = Datasource.create_datasource_band('red', '0', 100.0)\n",
     "band_two = Datasource.create_datasource_band('green', '1', 200.0)\n",
     "band_three = Datasource.create_datasource_band('blue', '2', 300.0)\n",
-    "result = Datasource.create(api, 'Test Datasource 5', [band_one, band_two, band_three])"
+    "bands = [band_one, band_two, band_three]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add a new datasource"
    ]
   },
   {
@@ -56,13 +77,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource = api.get_datasource_by_id(result.id)\n",
-    "datasource.name = datasource.name + ' updated'\n",
-    "datasource_dict = vars(datasource)['_Model__dict']\n",
-    "datasource_dict['createdAt'] = datasource.createdAt.isoformat()\n",
-    "datasource_dict['modifiedAt'] = datasource.modifiedAt.isoformat()\n",
-    "datasource_dict\n",
-    "Datasource.update(api, datasource.id, datasource_dict)"
+    "new_datasource = Datasource.create(api, 'Test Datasource 1', bands)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get datasource by ID"
    ]
   },
   {
@@ -70,7 +92,43 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "new_datasource_back = api.get_datasource_by_id(new_datasource.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Update a datasource"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_datasource_back.name = new_datasource_back.name + ' updated'\n",
+    "datasource_dict = vars(new_datasource_back)['_Model__dict']\n",
+    "Datasource.update(api, new_datasource_back.id, datasource_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a datasource"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Datasource.delete(api, new_datasource_back.id)"
+   ]
   }
  ],
  "metadata": {

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -20,7 +20,7 @@ except ImportError:
 
 SPEC_PATH = os.getenv(
     'RF_API_SPEC_PATH',
-    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature/asu/update-first-class-object-crud-spec/spec/spec.yml'  # NOQA
+    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/1.4.0/spec/spec.yml'  # NOQA
 )
 
 

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -10,7 +10,7 @@ from simplejson import JSONDecodeError
 
 from .aws.s3 import str_to_file
 from .exceptions import RefreshTokenException
-from .models import Analysis, MapToken, Project, Export
+from .models import Analysis, MapToken, Project, Export, Datasource
 from .settings import RV_TEMP_URI
 
 try:
@@ -18,10 +18,10 @@ try:
 except ImportError:
     from urlparse import urlparse
 
-
 SPEC_PATH = os.getenv(
     'RF_API_SPEC_PATH',
-    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/1.4.0/spec/spec.yml'
+    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature' +
+    '/asu/update-first-class-objects-crud-specs/spec/spec.yml'
 )
 
 
@@ -167,8 +167,11 @@ class API(object):
                 exports.append(Export(export, self))
         return exports
 
-    def get_datasources(self, **kwargs):
-        return self.client.Datasources.get_datasources(**kwargs).result()
+    def get_datasources(self):
+        datasources = []
+        for datasource in self.client.Datasources.get_datasources().result().results:
+            datasources.append(Datasource(datasource, self))
+        return datasources
 
     def get_scenes(self, **kwargs):
         bbox = kwargs.get('bbox')

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -20,8 +20,7 @@ except ImportError:
 
 SPEC_PATH = os.getenv(
     'RF_API_SPEC_PATH',
-    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature' +
-    '/asu/update-first-class-objects-crud-specs/spec/spec.yml'
+    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature/asu/update-first-class-object-crud-spec/spec/spec.yml'  # NOQA
 )
 
 
@@ -172,6 +171,10 @@ class API(object):
         for datasource in self.client.Datasources.get_datasources().result().results:
             datasources.append(Datasource(datasource, self))
         return datasources
+
+    def get_datasource_by_id(self, datasource_id):
+        return self.client.Datasources.get_datasources_datasourceID(
+            datasourceID=datasource_id).result()
 
     def get_scenes(self, **kwargs):
         bbox = kwargs.get('bbox')

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -20,7 +20,7 @@ except ImportError:
 
 SPEC_PATH = os.getenv(
     'RF_API_SPEC_PATH',
-    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/1.4.0/spec/spec.yml'  # NOQA
+    'https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/1.11.0/spec/spec.yml'  # NOQA
 )
 
 
@@ -203,7 +203,7 @@ class API(object):
         project_configs = []
         for project_ind, project_id in enumerate(project_ids):
             proj = Project(
-                self.client.Imagery.get_projects_uuid(uuid=project_id).result(),
+                self.client.Imagery.get_projects_projectID(projectID=project_id).result(),
                 self)
 
             if annotations_uris is None:

--- a/rasterfoundry/models/__init__.py
+++ b/rasterfoundry/models/__init__.py
@@ -3,3 +3,4 @@ from .map_token import MapToken # NOQA
 from .upload import Upload # NOQA
 from .analysis import Analysis # NOQA
 from .export import Export # NOQA
+from .datasource import Datasource # NOQA

--- a/rasterfoundry/models/analysis.py
+++ b/rasterfoundry/models/analysis.py
@@ -162,8 +162,8 @@ class Analysis(object):
             # fetch first one from api and use that project's coordinates
             input = inputs.pop()
             project = Project(
-                self.api.client.Imagery.get_projects_uuid(
-                    uuid=input.get('projId')
+                self.api.client.Imagery.get_projects_projectID(
+                    projectID=input.get('projId')
                 ).result(),
                 self.api
             )

--- a/rasterfoundry/models/datasource.py
+++ b/rasterfoundry/models/datasource.py
@@ -75,3 +75,8 @@ class Datasource(object):
     def update(cls, api, datasource_id, datasource):
         return api.client.Datasources.put_datasources_datasourceID(
             datasourceID=datasource_id, datasource=datasource).result()
+
+    @classmethod
+    def delete(cls, api, datasource_id):
+        return api.client.Datasources.delete_datasources_datasourceID(
+            datasourceID=datasource_id).result()

--- a/rasterfoundry/models/datasource.py
+++ b/rasterfoundry/models/datasource.py
@@ -69,4 +69,9 @@ class Datasource(object):
                 }
             }
         )
-        return api.client.Datasources.post_datasources(Datasource=datasource_created).result()
+        return api.client.Datasources.post_datasources(datasource=datasource_created).result()
+
+    @classmethod
+    def update(cls, api, datasource_id, datasource):
+        return api.client.Datasources.put_datasources_datasourceID(
+            datasourceID=datasource_id, datasource=datasource).result()

--- a/rasterfoundry/models/datasource.py
+++ b/rasterfoundry/models/datasource.py
@@ -1,0 +1,72 @@
+"""A Datasource is a source of data a scene uses"""
+
+
+class Datasource(object):
+    """A Raster Foundry datasource"""
+
+    def __repr__(self):
+        return '<Datasource - {}>'.format(self.name)
+
+    def __init__(self, datasource, api):
+        """Instantiate a new Datasource
+
+        Args:
+            datasource (Datasource): generated Datasource object from specification
+            api (API): api used to make requests on behalf of a datasource
+        """
+        self._datasource = datasource
+        self.api = api
+
+        # A few things we care about
+        self.name = datasource.name
+        self.id = datasource.id
+
+    @classmethod
+    def create_datasource_band(cls, name, number, wavelength):
+        """Create a datasource band
+
+        Args:
+            name (str): name of band, e.g. 'read', 'blue', 'infrared', etc.
+            number (str): band number
+            wavelength (str): wavelength
+
+        Returns:
+            dict: a band definition of a datasource band
+        """
+        return dict(
+            name=name,
+            number=number,
+            wavelength=wavelength
+        )
+
+    @classmethod
+    def create(cls, api, name, bands, visibility='PRIVATE', extras={}):
+        """Post an upload to Raster Foundry for processing
+
+        Args:
+            api (API): API to use for requests
+            name (str): name of datasource
+            bands (array): an array of create_datasource_band
+            visibility (str): datasource visibility, 'PRIVATE' by default
+            extras (dict): additional related information for a datasource, {} by default
+
+        Returns:
+            Datasource: created datasource object in Raster Foundry
+        """
+        datasource_created = dict(
+            name=name,
+            bands=bands,
+            visibility=visibility,
+            extras=extras,
+            composites={
+                'natural': {
+                    'label': 'Default',
+                    'value': {
+                        'redBand': 0,
+                        'greenBand': 1,
+                        'blueBand': 2
+                    }
+                }
+            }
+        )
+        return api.client.Datasources.post_datasources(Datasource=datasource_created).result()

--- a/rasterfoundry/models/export.py
+++ b/rasterfoundry/models/export.py
@@ -35,7 +35,8 @@ class Export(object):
     @property
     def files(self):
         try:
-            fnames_res = self.api.client.Imagery.get_exports_uuid_files(uuid=self.id).result()
+            fnames_res = self.api.client.Imagery.get_exports_exportID_files(
+                exportID=self.id).result()
             fnames = filter(
                 lambda name: name.upper() != 'RFUploadAccessTestFile'.upper(),
                 fnames_res)
@@ -74,11 +75,11 @@ class Export(object):
                 'function will never return. You may have left off FAILED by accident. '
                 'If that is the case, you should include FAILED in until and try again.'
             )
-        export = api.client.Imagery.get_exports_uuid(uuid=export_id).result()
+        export = api.client.Imagery.get_exports_exportID(exportID=export_id).result()
         while export.exportStatus not in until:
             time.sleep(delay)
-            export = api.client.Imagery.get_exports_uuid(
-                uuid=export_id).result()
+            export = api.client.Imagery.get_exports_exportID(
+                exportID=export_id).result()
         return Export(export, api)
 
     @classmethod

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -189,13 +189,13 @@ class Project(object):
                 'confidence': properties['score']
             }
 
-        self.api.client.Imagery.post_projects_uuid_annotations(
-            uuid=self.id, annotations=rf_annotations).future.result()
+        self.api.client.Imagery.post_projects_projectID_annotations(
+            projectID=self.id, annotations=rf_annotations).future.result()
 
     def get_annotations(self):
         def get_page(page):
-            return self.api.client.Imagery.get_projects_uuid_annotations(
-                uuid=self.id, page=page).result()
+            return self.api.client.Imagery.get_projects_projectID_annotations(
+                projectID=self.id, page=page).result()
 
         return get_all_paginated(get_page, list_field='features')
 
@@ -214,15 +214,15 @@ class Project(object):
 
     def get_scenes(self):
         def get_page(page):
-            return self.api.client.Imagery.get_projects_uuid_scenes(
-                uuid=self.id, page=page).result()
+            return self.api.client.Imagery.get_projects_projectID_scenes(
+                projectID=self.id, page=page).result()
 
         return get_all_paginated(get_page)
 
     def get_ordered_scene_ids(self):
         def get_page(page):
-            return self.api.client.Imagery.get_projects_uuid_order(
-                uuid=self.id, page=page).result()
+            return self.api.client.Imagery.get_projects_projectID_order(
+                projectID=self.id, page=page).result()
 
         # Need to reverse so that order is from bottom-most to top-most layer.
         return list(reversed(get_all_paginated(get_page)))


### PR DESCRIPTION
This PR:
- adds some convenience functions for datasources' CRUD
- adds an example notebook for it

How to test:
- Point to spec in here `https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature/asu/update-first-class-object-crud-spec/spec/spec.yml`
- Run the example notebook

This is the first part of https://github.com/raster-foundry/raster-foundry-python-client/issues/53