### PR TITLE
Use new name for tokens endpoint post

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,6 @@ Added
 Changed
 ~~~~~~~
 
--  Switched auth payload body parameter to keep up with spec changes
-   `#70 <https://github.com/raster-foundry/raster-foundry-python-client/pull/70>`__
-
 Deprecated
 ~~~~~~~~~~
 
@@ -21,6 +18,9 @@ Removed
 
 Fixed
 ~~~~~
+
+-  Switched auth payload body parameter to keep up with spec changes
+   `#70 <https://github.com/raster-foundry/raster-foundry-python-client/pull/70>`__
 
 Security
 ~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Added
 Changed
 ~~~~~~~
 
+-  Switched auth payload body parameter to keep up with spec changes
+   `#70 <https://github.com/raster-foundry/raster-foundry-python-client/pull/70>`__
+
 Deprecated
 ~~~~~~~~~~
 

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -82,7 +82,7 @@ class API(object):
 
         try:
             response = self.client.Authentication.post_tokens(
-                refreshToken=post_body).future.result()
+                authBody=post_body).future.result()
             return response.json()['id_token']
         except JSONDecodeError:
             raise RefreshTokenException('Error using refresh token, please '


### PR DESCRIPTION
## Overview

This PR updates client initialization to use the new auth payload name from the spec. Having a parameter
named `refreshToken` that expects to have a key `refresh_token` was confusing, but no longer must we toil under the weight of our past deceptions.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-python-client/blob/develop/CHANGELOG.rst) and grouped with similar changes if possible

## Testing Instructions

 * Initialize a client
 * it should work