### PR TITLE
Make the post body for auth reflect the current API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Removed
 Fixed
 ~~~~~
 
+- Made authentication POST body correct for the authentication API `#71 <https://github.com/raster-foundry/raster-foundry-api-spec/pull/71>`__
+
 Security
 ~~~~~~~~
 

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -82,7 +82,7 @@ class API(object):
 
         try:
             response = self.client.Authentication.post_tokens(
-                refreshToken=post_body).future.result()
+                authBody=post_body).future.result()
             return response.json()['id_token']
         except JSONDecodeError:
             raise RefreshTokenException('Error using refresh token, please '


### PR DESCRIPTION
## Overview

The spec says `authBody`. We should make it match.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-python-client/blob/develop/CHANGELOG.rst) and grouped with similar changes if possible

## Testing Instructions

 * initialize a client with a refresh token
 * it should work