### PR TITLE
Add GitHub issue template for releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,6 +14,7 @@ $ git flow release start X.Y.Z
 - [ ] Edit `setup.py` to reflect the version of this release
 - [ ] Bump spec version (if applicable)
 - [ ] Rotate `CHANGELOG.rst` (following [Keep a Changelog](https://keepachangelog.com/) principles)
+- [ ] Ensure outstanding changes are committed:
 ```bash
 $ git add .
 $ git commit -m "X.Y.Z"

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,6 +13,16 @@ $ git flow release start X.Y.Z
 ```
 - [ ] Edit `setup.py` to reflect the version of this release
 - [ ] Bump spec version (if applicable)
+- [ ] Rotate `CHANGELOG.rst`:
+* copy everything from unreleased into a new section for the release number you're working on. This should include a link to the tag in GitHub
+* remove unused sections, e.g., if there are no security changes
+* delete everything in the current unreleased section
+* create a fresh unreleased section at the top of the changelog
+- [ ] Ensure outstanding changes are committed:
+```bash
+$ git add .
+$ git commit -m "X.Y.Z"
+```
 - [ ] Finalize and publish release branch:
 ```bash
 $ git flow release finish X.Y.Z

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,23 @@
+---
+name: Release
+about: When ready to cut a release
+title: Release X.Y.Z
+labels: ''
+assignees: ''
+
+---
+
+- [ ] Create release branch:
+```bash
+$ git flow release start X.Y.Z
+```
+- [ ] Edit `setup.py` to reflect the version of this release
+- [ ] Bump spec version (if applicable)
+- [ ] Finalize and publish release branch:
+```bash
+$ git flow release finish X.Y.Z
+$ git push origin develop
+$ git checkout master
+$ git push origin master
+$ git push --tags
+```

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,7 +2,7 @@
 name: Release
 about: When ready to cut a release
 title: Release X.Y.Z
-labels: ''
+labels: 'release'
 assignees: ''
 
 ---
@@ -13,12 +13,7 @@ $ git flow release start X.Y.Z
 ```
 - [ ] Edit `setup.py` to reflect the version of this release
 - [ ] Bump spec version (if applicable)
-- [ ] Rotate `CHANGELOG.rst`:
-* copy everything from unreleased into a new section for the release number you're working on. This should include a link to the tag in GitHub
-* remove unused sections, e.g., if there are no security changes
-* delete everything in the current unreleased section
-* create a fresh unreleased section at the top of the changelog
-- [ ] Ensure outstanding changes are committed:
+- [ ] Rotate `CHANGELOG.rst` (following [Keep a Changelog](https://keepachangelog.com/) principles)
 ```bash
 $ git add .
 $ git commit -m "X.Y.Z"


### PR DESCRIPTION
## Overview

I followed https://help.github.com/en/articles/creating-issue-templates-for-your-repository to create a GitHub issue template containing the release workflow for this repository. 

For each new release, an issue should be created, the person doing the release should assign themselves, and then the checklist should be worked through.

Closes #73 

## Demo

<img width="740" alt="image" src="https://user-images.githubusercontent.com/1774125/54165179-04258000-4436-11e9-95a9-6f51160c4284.png">
