### PR TITLE
Use setuptools_scm to manage Python package version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Change Log
 Added
 ~~~~~
 
+-  Use setuptools_scm to manage Python package version
+   `#76 <https://github.com/raster-foundry/raster-foundry-python-client/pull/76>`__
+
 Changed
 ~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="rasterfoundry",
-    version="1.16.2",
+    use_scm_version=True,
     description='A Python client for Raster Foundry, a web platform for '
     'combining, analyzing, and publishing raster data.',
     long_description=open('README.rst').read(),
@@ -37,5 +37,6 @@ setuptools.setup(
         'dev': [],
         'test': [],
     },
-    tests_require=[]
+    setup_requires=['setuptools_scm'],
+    tests_require=[],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setuptools.setup(
         'dev': [],
         'test': [],
     },
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm==3.*'],
     tests_require=[],
 )


### PR DESCRIPTION
## Overview

Use [`setuptools_scm`](https://pypi.org/project/setuptools-scm/) to manage the Python package version. 

This improves deployment ergonomics by eliminating one of the Release Workflow steps [here](
https://github.com/azavea/raster-foundry-deployment/wiki/Release-Workflow#bump-version-in-setuppy-and-spec-version-raster-foundryraster-foundry-python-client-only).

Closes #74 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-python-client/blob/develop/CHANGELOG.rst) and grouped with similar changes if possible

## Testing Instructions

Confirm the version number locally via `setup.py`:

```bash
$ python setup.py --version
1.16.3.dev2+g3259748
```

Add an annotated tag and confirm the version number locally again:

```bash
$ git tag -a 1.16.4 -m 1.16.4
$ python setup.py --version
1.16.4
```

Travis is configured to only deploy with `on.tags: true` (if and only if the build is a tagged build), so the version of the PyPi package should match whatever `$ git flow release start X.Y.Z` version we use.